### PR TITLE
chore: bump Rsbuild 0.0.24 and remove temp code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-rsbuild",
+  "name": "remix",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -8,8 +8,8 @@
         "esbuild": "^0.19.5"
       },
       "devDependencies": {
-        "@rsbuild/core": "^0.0.23",
-        "@rsbuild/shared": "^0.0.23"
+        "@rsbuild/core": "^0.0.24",
+        "@rsbuild/shared": "^0.0.24"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -407,13 +407,13 @@
       "dev": true
     },
     "node_modules/@rsbuild/core": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.23.tgz",
-      "integrity": "sha512-NnmCl58FiXofFLvjCwXiKF8dDVmcnG08/iozvEeMW4QQmaWwTigZ7DUB0VCHWH+bjCQopYpFdk3UMH0aLIi73g==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
+      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
       "dev": true,
       "dependencies": {
-        "@rsbuild/shared": "0.0.23",
-        "@rspack/core": "0.3.12",
+        "@rsbuild/shared": "0.0.24",
+        "@rspack/core": "0.3.13",
         "core-js": "~3.32.2",
         "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
         "http-proxy-middleware": "^2.0.1",
@@ -431,12 +431,12 @@
       }
     },
     "node_modules/@rsbuild/shared": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.23.tgz",
-      "integrity": "sha512-VFwTbAAMx+OePQtmrPs2ocRSKpCsyxoyt5FrnhxWIGw+viVdTKuE4HONIPb2KpmP3lUfpo0aDRhrm9TEnUmnUA==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.24.tgz",
+      "integrity": "sha512-xfLPZE1arTlgiKQVQfplCCYkp32j5l7vApOqDdzfjoCDpmQa9pcw6sRThrdzfpkrY2zkGZ5tc/9LICKH0C/Ezg==",
       "dev": true,
       "dependencies": {
-        "@rspack/core": "0.3.12",
+        "@rspack/core": "0.3.13",
         "caniuse-lite": "^1.0.30001559",
         "json5": "^2.2.3",
         "line-diff": "2.1.1",
@@ -446,26 +446,26 @@
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.12.tgz",
-      "integrity": "sha512-UC+JMLqmN9IBfk6PIjH5LW+/XlESCXAV1L1Sdtiwagjp2O5ES/vRYb7j8InqXk87o30drCtdC0igZColSiX/tQ==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.13.tgz",
+      "integrity": "sha512-4ZktTw7IxE7XR4JwKlja08jww4u3FyzT2YxPpykPvUupR69zjkznXKJX4IZ8LVXbc/hKCdrULtaUKlfT+9ir1Q==",
       "dev": true,
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "0.3.12",
-        "@rspack/binding-darwin-x64": "0.3.12",
-        "@rspack/binding-linux-arm64-gnu": "0.3.12",
-        "@rspack/binding-linux-arm64-musl": "0.3.12",
-        "@rspack/binding-linux-x64-gnu": "0.3.12",
-        "@rspack/binding-linux-x64-musl": "0.3.12",
-        "@rspack/binding-win32-arm64-msvc": "0.3.12",
-        "@rspack/binding-win32-ia32-msvc": "0.3.12",
-        "@rspack/binding-win32-x64-msvc": "0.3.12"
+        "@rspack/binding-darwin-arm64": "0.3.13",
+        "@rspack/binding-darwin-x64": "0.3.13",
+        "@rspack/binding-linux-arm64-gnu": "0.3.13",
+        "@rspack/binding-linux-arm64-musl": "0.3.13",
+        "@rspack/binding-linux-x64-gnu": "0.3.13",
+        "@rspack/binding-linux-x64-musl": "0.3.13",
+        "@rspack/binding-win32-arm64-msvc": "0.3.13",
+        "@rspack/binding-win32-ia32-msvc": "0.3.13",
+        "@rspack/binding-win32-x64-msvc": "0.3.13"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.12.tgz",
-      "integrity": "sha512-ObnwLPnN4ylD7sTkm6foRHZEX0y+tJTssDX5kebrGSCMaW68OT4JFacmI/3HOQemJEgyL9m5Bp3I7kithzMOtA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.13.tgz",
+      "integrity": "sha512-mXAmBn+cvG1o5p8F3IYIq9Mn4g1u/xGY++MwuAtWMwx7IFrZR+94j9W9K4JKGfixiuUFB2FsVOT5AdxWiqTO5w==",
       "cpu": [
         "arm64"
       ],
@@ -476,9 +476,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.12.tgz",
-      "integrity": "sha512-WYFNDUcIeg+4s3aJ0FtwmqR94MbeyIKYfNgZ0LJf+cmCZHRVtizyxiUm5hsWJpEhBWKGzcMXPvykc5LyjJ6YRw==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.13.tgz",
+      "integrity": "sha512-l55X39ZrF8V90V4vpbDkXi103L8XSDMgS26XYhy5TqSSaqRlImaoaVDOxIjREWtR1MmuUf+BlLlXvu/DtR4wTw==",
       "cpu": [
         "x64"
       ],
@@ -489,9 +489,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.12.tgz",
-      "integrity": "sha512-6mTBtkpprRiUTO1D84yZtOTmSLkGtTfD79jkBkQ8UHjyXas7NWJHCMVNcBK417NcAJ6jxfGVXZrp7e1ERTfFfw==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.13.tgz",
+      "integrity": "sha512-AQx0PaeYcq+k1A3wmHsgZNN5qkGv2a5dUwTSK53DIn0e5tTIZQNKSllBRUyDKrV2TQcvFRJxm/t5MIj7CxgUIg==",
       "cpu": [
         "arm64"
       ],
@@ -502,9 +502,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.12.tgz",
-      "integrity": "sha512-jvTjx8KDkkRuGTI43PBUtfft1JfpLO41xyd8q4teFkSmZ54xhgBwyph3k7NCK+MP3rMwiNhFJLphObpQfU/djg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.13.tgz",
+      "integrity": "sha512-FvPAERun7iLiNd9vKEpP9d1q26GDk9sqc7hr2qG3A28VX32BfyB2C6vqe2UxZtxut9ETbbSzAFeDAvctZnXfkg==",
       "cpu": [
         "arm64"
       ],
@@ -515,9 +515,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.12.tgz",
-      "integrity": "sha512-nbFJgAh97iirsRlRFXLkWFolqdnJ9vo9mRc+EpH2pvbY/FDSUgAXfzIfbKAoN+Ll4UzlqMUOa6v+WZ3VOcMCeg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.13.tgz",
+      "integrity": "sha512-Bss5h5YenETDn7CiXlTSb7vNEUEHGiLOjO5YbozUEEnvlLRHJemh2bFLyv2k/wEpkgi+ZkSyKWw6ESHTfXfadQ==",
       "cpu": [
         "x64"
       ],
@@ -528,9 +528,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.12.tgz",
-      "integrity": "sha512-yuYD5Vj/H9O66/L2CgnILqkaEpN4ZWTxmYNKOpEm+IxEuOYuMX9aDkY6ks9Qhkb1+iOK9SrruZ7BGd0avUnMUg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.13.tgz",
+      "integrity": "sha512-treRV2h5g4+PSdCpnX9cSttWm9r+JtS7NrlYLF/5OcBhI8NGC/vex9wMObz1fCKiuHD/l1IPxqfeZN6JRz3sEA==",
       "cpu": [
         "x64"
       ],
@@ -541,9 +541,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.12.tgz",
-      "integrity": "sha512-lHpt54ci90ahwD3YujcA+KZmkqjhTA/+kfTknYxiIzC+25pn+fY8cAvlieZT7lgZeglf8I2GyLTywjUV+D75ng==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.13.tgz",
+      "integrity": "sha512-aIOAYsDGxQrK2cIOAqx1LLXQZcid9s1GgZ842Knas2jlBap2DtWNg3qoULBkVg0eHiLlYd7Sfe7wGjiQF/2UiA==",
       "cpu": [
         "arm64"
       ],
@@ -554,9 +554,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.12.tgz",
-      "integrity": "sha512-9aU4LmNVLDOumcruOvv1+y6XgNP8SCVreCY27wohrj2ISkG3JPQvJo3hkHOqo5xU1ZQlvdauGI7rXL8rBqV7vA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.13.tgz",
+      "integrity": "sha512-OWP9GLJYxawTJ/dZnAO1YWmgLR9hScRmUZeCAbhCGD5niGBBke7IZWLi1Yk3AvZFXcUi/DAKiXCrSj7d1HvOHg==",
       "cpu": [
         "ia32"
       ],
@@ -567,9 +567,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.12.tgz",
-      "integrity": "sha512-KckmVXMVW9sCifqR3tOatPM9YrP8ylH53NgcgqvaKnkAadK5kcT/y0u2gM54ThM9eA0oi0PDoCJARTDRbxRjGQ==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.13.tgz",
+      "integrity": "sha512-/FY3w+IGMYvCCl5WV+IZQNieeC0d2SNA2xpsEUHp57JbXbP5TQBcIaMpPXLOw3Be67qsehmbAcpJkMaFR2/3EA==",
       "cpu": [
         "x64"
       ],
@@ -580,13 +580,12 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.12.tgz",
-      "integrity": "sha512-61my6rVPLYSmouzZBs6SeUJEUZCOsHLOJlrs+Gj90tZfEv2YtZX3uj3Kqeiitx6NrFoQUz9/aD9UJB+5eJ2Dsw==",
-      "deprecated": "contains a serious artifacts bug",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.13.tgz",
+      "integrity": "sha512-YCJ1d4HGj/MVkm/JDQwTFFKd2/tjJwAok1FLR5nBLN4AfDBlv9cwB3QhM3ZTNvECmk/Gk7esDsCQpI3Gt1rNkA==",
       "dev": true,
       "dependencies": {
-        "@rspack/binding": "0.3.12",
+        "@rspack/binding": "0.3.13",
         "@swc/helpers": "0.5.1",
         "browserslist": "^4.21.3",
         "compare-versions": "6.0.0-rc.1",
@@ -1746,13 +1745,13 @@
       "dev": true
     },
     "@rsbuild/core": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.23.tgz",
-      "integrity": "sha512-NnmCl58FiXofFLvjCwXiKF8dDVmcnG08/iozvEeMW4QQmaWwTigZ7DUB0VCHWH+bjCQopYpFdk3UMH0aLIi73g==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
+      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
       "dev": true,
       "requires": {
-        "@rsbuild/shared": "0.0.23",
-        "@rspack/core": "0.3.12",
+        "@rsbuild/shared": "0.0.24",
+        "@rspack/core": "0.3.13",
         "core-js": "~3.32.2",
         "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
         "http-proxy-middleware": "^2.0.1",
@@ -1764,12 +1763,12 @@
       }
     },
     "@rsbuild/shared": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.23.tgz",
-      "integrity": "sha512-VFwTbAAMx+OePQtmrPs2ocRSKpCsyxoyt5FrnhxWIGw+viVdTKuE4HONIPb2KpmP3lUfpo0aDRhrm9TEnUmnUA==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.24.tgz",
+      "integrity": "sha512-xfLPZE1arTlgiKQVQfplCCYkp32j5l7vApOqDdzfjoCDpmQa9pcw6sRThrdzfpkrY2zkGZ5tc/9LICKH0C/Ezg==",
       "dev": true,
       "requires": {
-        "@rspack/core": "0.3.12",
+        "@rspack/core": "0.3.13",
         "caniuse-lite": "^1.0.30001559",
         "json5": "^2.2.3",
         "line-diff": "2.1.1",
@@ -1779,92 +1778,92 @@
       }
     },
     "@rspack/binding": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.12.tgz",
-      "integrity": "sha512-UC+JMLqmN9IBfk6PIjH5LW+/XlESCXAV1L1Sdtiwagjp2O5ES/vRYb7j8InqXk87o30drCtdC0igZColSiX/tQ==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.13.tgz",
+      "integrity": "sha512-4ZktTw7IxE7XR4JwKlja08jww4u3FyzT2YxPpykPvUupR69zjkznXKJX4IZ8LVXbc/hKCdrULtaUKlfT+9ir1Q==",
       "dev": true,
       "requires": {
-        "@rspack/binding-darwin-arm64": "0.3.12",
-        "@rspack/binding-darwin-x64": "0.3.12",
-        "@rspack/binding-linux-arm64-gnu": "0.3.12",
-        "@rspack/binding-linux-arm64-musl": "0.3.12",
-        "@rspack/binding-linux-x64-gnu": "0.3.12",
-        "@rspack/binding-linux-x64-musl": "0.3.12",
-        "@rspack/binding-win32-arm64-msvc": "0.3.12",
-        "@rspack/binding-win32-ia32-msvc": "0.3.12",
-        "@rspack/binding-win32-x64-msvc": "0.3.12"
+        "@rspack/binding-darwin-arm64": "0.3.13",
+        "@rspack/binding-darwin-x64": "0.3.13",
+        "@rspack/binding-linux-arm64-gnu": "0.3.13",
+        "@rspack/binding-linux-arm64-musl": "0.3.13",
+        "@rspack/binding-linux-x64-gnu": "0.3.13",
+        "@rspack/binding-linux-x64-musl": "0.3.13",
+        "@rspack/binding-win32-arm64-msvc": "0.3.13",
+        "@rspack/binding-win32-ia32-msvc": "0.3.13",
+        "@rspack/binding-win32-x64-msvc": "0.3.13"
       }
     },
     "@rspack/binding-darwin-arm64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.12.tgz",
-      "integrity": "sha512-ObnwLPnN4ylD7sTkm6foRHZEX0y+tJTssDX5kebrGSCMaW68OT4JFacmI/3HOQemJEgyL9m5Bp3I7kithzMOtA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.13.tgz",
+      "integrity": "sha512-mXAmBn+cvG1o5p8F3IYIq9Mn4g1u/xGY++MwuAtWMwx7IFrZR+94j9W9K4JKGfixiuUFB2FsVOT5AdxWiqTO5w==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-darwin-x64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.12.tgz",
-      "integrity": "sha512-WYFNDUcIeg+4s3aJ0FtwmqR94MbeyIKYfNgZ0LJf+cmCZHRVtizyxiUm5hsWJpEhBWKGzcMXPvykc5LyjJ6YRw==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.13.tgz",
+      "integrity": "sha512-l55X39ZrF8V90V4vpbDkXi103L8XSDMgS26XYhy5TqSSaqRlImaoaVDOxIjREWtR1MmuUf+BlLlXvu/DtR4wTw==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-arm64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.12.tgz",
-      "integrity": "sha512-6mTBtkpprRiUTO1D84yZtOTmSLkGtTfD79jkBkQ8UHjyXas7NWJHCMVNcBK417NcAJ6jxfGVXZrp7e1ERTfFfw==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.13.tgz",
+      "integrity": "sha512-AQx0PaeYcq+k1A3wmHsgZNN5qkGv2a5dUwTSK53DIn0e5tTIZQNKSllBRUyDKrV2TQcvFRJxm/t5MIj7CxgUIg==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-arm64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.12.tgz",
-      "integrity": "sha512-jvTjx8KDkkRuGTI43PBUtfft1JfpLO41xyd8q4teFkSmZ54xhgBwyph3k7NCK+MP3rMwiNhFJLphObpQfU/djg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.13.tgz",
+      "integrity": "sha512-FvPAERun7iLiNd9vKEpP9d1q26GDk9sqc7hr2qG3A28VX32BfyB2C6vqe2UxZtxut9ETbbSzAFeDAvctZnXfkg==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-x64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.12.tgz",
-      "integrity": "sha512-nbFJgAh97iirsRlRFXLkWFolqdnJ9vo9mRc+EpH2pvbY/FDSUgAXfzIfbKAoN+Ll4UzlqMUOa6v+WZ3VOcMCeg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.13.tgz",
+      "integrity": "sha512-Bss5h5YenETDn7CiXlTSb7vNEUEHGiLOjO5YbozUEEnvlLRHJemh2bFLyv2k/wEpkgi+ZkSyKWw6ESHTfXfadQ==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-x64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.12.tgz",
-      "integrity": "sha512-yuYD5Vj/H9O66/L2CgnILqkaEpN4ZWTxmYNKOpEm+IxEuOYuMX9aDkY6ks9Qhkb1+iOK9SrruZ7BGd0avUnMUg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.13.tgz",
+      "integrity": "sha512-treRV2h5g4+PSdCpnX9cSttWm9r+JtS7NrlYLF/5OcBhI8NGC/vex9wMObz1fCKiuHD/l1IPxqfeZN6JRz3sEA==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-win32-arm64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.12.tgz",
-      "integrity": "sha512-lHpt54ci90ahwD3YujcA+KZmkqjhTA/+kfTknYxiIzC+25pn+fY8cAvlieZT7lgZeglf8I2GyLTywjUV+D75ng==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.13.tgz",
+      "integrity": "sha512-aIOAYsDGxQrK2cIOAqx1LLXQZcid9s1GgZ842Knas2jlBap2DtWNg3qoULBkVg0eHiLlYd7Sfe7wGjiQF/2UiA==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-win32-ia32-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.12.tgz",
-      "integrity": "sha512-9aU4LmNVLDOumcruOvv1+y6XgNP8SCVreCY27wohrj2ISkG3JPQvJo3hkHOqo5xU1ZQlvdauGI7rXL8rBqV7vA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.13.tgz",
+      "integrity": "sha512-OWP9GLJYxawTJ/dZnAO1YWmgLR9hScRmUZeCAbhCGD5niGBBke7IZWLi1Yk3AvZFXcUi/DAKiXCrSj7d1HvOHg==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-win32-x64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.12.tgz",
-      "integrity": "sha512-KckmVXMVW9sCifqR3tOatPM9YrP8ylH53NgcgqvaKnkAadK5kcT/y0u2gM54ThM9eA0oi0PDoCJARTDRbxRjGQ==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.13.tgz",
+      "integrity": "sha512-/FY3w+IGMYvCCl5WV+IZQNieeC0d2SNA2xpsEUHp57JbXbP5TQBcIaMpPXLOw3Be67qsehmbAcpJkMaFR2/3EA==",
       "dev": true,
       "optional": true
     },
     "@rspack/core": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.12.tgz",
-      "integrity": "sha512-61my6rVPLYSmouzZBs6SeUJEUZCOsHLOJlrs+Gj90tZfEv2YtZX3uj3Kqeiitx6NrFoQUz9/aD9UJB+5eJ2Dsw==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.13.tgz",
+      "integrity": "sha512-YCJ1d4HGj/MVkm/JDQwTFFKd2/tjJwAok1FLR5nBLN4AfDBlv9cwB3QhM3ZTNvECmk/Gk7esDsCQpI3Gt1rNkA==",
       "dev": true,
       "requires": {
-        "@rspack/binding": "0.3.12",
+        "@rspack/binding": "0.3.13",
         "@swc/helpers": "0.5.1",
         "browserslist": "^4.21.3",
         "compare-versions": "6.0.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
-    "@rsbuild/core": "^0.0.23",
-    "@rsbuild/shared": "^0.0.23"
+    "@rsbuild/core": "^0.0.24",
+    "@rsbuild/shared": "^0.0.24"
   },
   "dependencies": {
     "esbuild": "^0.19.5"

--- a/playground/build.mjs
+++ b/playground/build.mjs
@@ -10,8 +10,6 @@ const start = async () => {
     target: ['node'],
     rsbuildConfig: config,
   })
-  client.addPlugins(config.plugins);
-  server.addPlugins(config.plugins);
   await client.build();
   // await server.build();
 };

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -11,13 +11,13 @@
         "@remix-run/dev": "^2.2.0",
         "@remix-run/node": "^2.2.0",
         "@remix-run/react": "^2.2.0",
-        "@rsbuild/shared": "^0.0.23",
+        "@rsbuild/shared": "^0.0.24",
         "@rspack/cli": "^0.3.13",
         "@rspack/core": "^0.3.13",
         "isbot": "latest"
       },
       "devDependencies": {
-        "@rsbuild/core": "^0.0.23",
+        "@rsbuild/core": "^0.0.24",
         "@types/node": "^20.9.0",
         "ts-node": "^10.9.1"
       }
@@ -1529,13 +1529,13 @@
       }
     },
     "node_modules/@rsbuild/core": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.23.tgz",
-      "integrity": "sha512-NnmCl58FiXofFLvjCwXiKF8dDVmcnG08/iozvEeMW4QQmaWwTigZ7DUB0VCHWH+bjCQopYpFdk3UMH0aLIi73g==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
+      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
       "dev": true,
       "dependencies": {
-        "@rsbuild/shared": "0.0.23",
-        "@rspack/core": "0.3.12",
+        "@rsbuild/shared": "0.0.24",
+        "@rspack/core": "0.3.13",
         "core-js": "~3.32.2",
         "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
         "http-proxy-middleware": "^2.0.1",
@@ -1552,325 +1552,18 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.12.tgz",
-      "integrity": "sha512-UC+JMLqmN9IBfk6PIjH5LW+/XlESCXAV1L1Sdtiwagjp2O5ES/vRYb7j8InqXk87o30drCtdC0igZColSiX/tQ==",
-      "dev": true,
-      "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "0.3.12",
-        "@rspack/binding-darwin-x64": "0.3.12",
-        "@rspack/binding-linux-arm64-gnu": "0.3.12",
-        "@rspack/binding-linux-arm64-musl": "0.3.12",
-        "@rspack/binding-linux-x64-gnu": "0.3.12",
-        "@rspack/binding-linux-x64-musl": "0.3.12",
-        "@rspack/binding-win32-arm64-msvc": "0.3.12",
-        "@rspack/binding-win32-ia32-msvc": "0.3.12",
-        "@rspack/binding-win32-x64-msvc": "0.3.12"
-      }
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-darwin-arm64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.12.tgz",
-      "integrity": "sha512-ObnwLPnN4ylD7sTkm6foRHZEX0y+tJTssDX5kebrGSCMaW68OT4JFacmI/3HOQemJEgyL9m5Bp3I7kithzMOtA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-darwin-x64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.12.tgz",
-      "integrity": "sha512-WYFNDUcIeg+4s3aJ0FtwmqR94MbeyIKYfNgZ0LJf+cmCZHRVtizyxiUm5hsWJpEhBWKGzcMXPvykc5LyjJ6YRw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.12.tgz",
-      "integrity": "sha512-6mTBtkpprRiUTO1D84yZtOTmSLkGtTfD79jkBkQ8UHjyXas7NWJHCMVNcBK417NcAJ6jxfGVXZrp7e1ERTfFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.12.tgz",
-      "integrity": "sha512-jvTjx8KDkkRuGTI43PBUtfft1JfpLO41xyd8q4teFkSmZ54xhgBwyph3k7NCK+MP3rMwiNhFJLphObpQfU/djg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.12.tgz",
-      "integrity": "sha512-nbFJgAh97iirsRlRFXLkWFolqdnJ9vo9mRc+EpH2pvbY/FDSUgAXfzIfbKAoN+Ll4UzlqMUOa6v+WZ3VOcMCeg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.12.tgz",
-      "integrity": "sha512-yuYD5Vj/H9O66/L2CgnILqkaEpN4ZWTxmYNKOpEm+IxEuOYuMX9aDkY6ks9Qhkb1+iOK9SrruZ7BGd0avUnMUg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.12.tgz",
-      "integrity": "sha512-lHpt54ci90ahwD3YujcA+KZmkqjhTA/+kfTknYxiIzC+25pn+fY8cAvlieZT7lgZeglf8I2GyLTywjUV+D75ng==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.12.tgz",
-      "integrity": "sha512-9aU4LmNVLDOumcruOvv1+y6XgNP8SCVreCY27wohrj2ISkG3JPQvJo3hkHOqo5xU1ZQlvdauGI7rXL8rBqV7vA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.12.tgz",
-      "integrity": "sha512-KckmVXMVW9sCifqR3tOatPM9YrP8ylH53NgcgqvaKnkAadK5kcT/y0u2gM54ThM9eA0oi0PDoCJARTDRbxRjGQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rsbuild/core/node_modules/@rspack/core": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.12.tgz",
-      "integrity": "sha512-61my6rVPLYSmouzZBs6SeUJEUZCOsHLOJlrs+Gj90tZfEv2YtZX3uj3Kqeiitx6NrFoQUz9/aD9UJB+5eJ2Dsw==",
-      "deprecated": "contains a serious artifacts bug",
-      "dev": true,
-      "dependencies": {
-        "@rspack/binding": "0.3.12",
-        "@swc/helpers": "0.5.1",
-        "browserslist": "^4.21.3",
-        "compare-versions": "6.0.0-rc.1",
-        "enhanced-resolve": "5.12.0",
-        "fast-querystring": "1.1.2",
-        "graceful-fs": "4.2.10",
-        "json-parse-even-better-errors": "^3.0.0",
-        "neo-async": "2.6.2",
-        "react-refresh": "0.14.0",
-        "tapable": "2.2.1",
-        "terminal-link": "^2.1.1",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "3.2.3",
-        "zod": "^3.21.4",
-        "zod-validation-error": "1.2.0"
-      }
-    },
     "node_modules/@rsbuild/shared": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.23.tgz",
-      "integrity": "sha512-VFwTbAAMx+OePQtmrPs2ocRSKpCsyxoyt5FrnhxWIGw+viVdTKuE4HONIPb2KpmP3lUfpo0aDRhrm9TEnUmnUA==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.24.tgz",
+      "integrity": "sha512-xfLPZE1arTlgiKQVQfplCCYkp32j5l7vApOqDdzfjoCDpmQa9pcw6sRThrdzfpkrY2zkGZ5tc/9LICKH0C/Ezg==",
       "dependencies": {
-        "@rspack/core": "0.3.12",
+        "@rspack/core": "0.3.13",
         "caniuse-lite": "^1.0.30001559",
         "json5": "^2.2.3",
         "line-diff": "2.1.1",
         "lodash": "^4.17.21",
         "postcss": "8.4.31",
         "semver": "^7.5.4"
-      }
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.12.tgz",
-      "integrity": "sha512-UC+JMLqmN9IBfk6PIjH5LW+/XlESCXAV1L1Sdtiwagjp2O5ES/vRYb7j8InqXk87o30drCtdC0igZColSiX/tQ==",
-      "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "0.3.12",
-        "@rspack/binding-darwin-x64": "0.3.12",
-        "@rspack/binding-linux-arm64-gnu": "0.3.12",
-        "@rspack/binding-linux-arm64-musl": "0.3.12",
-        "@rspack/binding-linux-x64-gnu": "0.3.12",
-        "@rspack/binding-linux-x64-musl": "0.3.12",
-        "@rspack/binding-win32-arm64-msvc": "0.3.12",
-        "@rspack/binding-win32-ia32-msvc": "0.3.12",
-        "@rspack/binding-win32-x64-msvc": "0.3.12"
-      }
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-darwin-arm64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.12.tgz",
-      "integrity": "sha512-ObnwLPnN4ylD7sTkm6foRHZEX0y+tJTssDX5kebrGSCMaW68OT4JFacmI/3HOQemJEgyL9m5Bp3I7kithzMOtA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-darwin-x64": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.12.tgz",
-      "integrity": "sha512-WYFNDUcIeg+4s3aJ0FtwmqR94MbeyIKYfNgZ0LJf+cmCZHRVtizyxiUm5hsWJpEhBWKGzcMXPvykc5LyjJ6YRw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.12.tgz",
-      "integrity": "sha512-6mTBtkpprRiUTO1D84yZtOTmSLkGtTfD79jkBkQ8UHjyXas7NWJHCMVNcBK417NcAJ6jxfGVXZrp7e1ERTfFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.12.tgz",
-      "integrity": "sha512-jvTjx8KDkkRuGTI43PBUtfft1JfpLO41xyd8q4teFkSmZ54xhgBwyph3k7NCK+MP3rMwiNhFJLphObpQfU/djg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.12.tgz",
-      "integrity": "sha512-nbFJgAh97iirsRlRFXLkWFolqdnJ9vo9mRc+EpH2pvbY/FDSUgAXfzIfbKAoN+Ll4UzlqMUOa6v+WZ3VOcMCeg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.12.tgz",
-      "integrity": "sha512-yuYD5Vj/H9O66/L2CgnILqkaEpN4ZWTxmYNKOpEm+IxEuOYuMX9aDkY6ks9Qhkb1+iOK9SrruZ7BGd0avUnMUg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.12.tgz",
-      "integrity": "sha512-lHpt54ci90ahwD3YujcA+KZmkqjhTA/+kfTknYxiIzC+25pn+fY8cAvlieZT7lgZeglf8I2GyLTywjUV+D75ng==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.12.tgz",
-      "integrity": "sha512-9aU4LmNVLDOumcruOvv1+y6XgNP8SCVreCY27wohrj2ISkG3JPQvJo3hkHOqo5xU1ZQlvdauGI7rXL8rBqV7vA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.12.tgz",
-      "integrity": "sha512-KckmVXMVW9sCifqR3tOatPM9YrP8ylH53NgcgqvaKnkAadK5kcT/y0u2gM54ThM9eA0oi0PDoCJARTDRbxRjGQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rsbuild/shared/node_modules/@rspack/core": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.12.tgz",
-      "integrity": "sha512-61my6rVPLYSmouzZBs6SeUJEUZCOsHLOJlrs+Gj90tZfEv2YtZX3uj3Kqeiitx6NrFoQUz9/aD9UJB+5eJ2Dsw==",
-      "deprecated": "contains a serious artifacts bug",
-      "dependencies": {
-        "@rspack/binding": "0.3.12",
-        "@swc/helpers": "0.5.1",
-        "browserslist": "^4.21.3",
-        "compare-versions": "6.0.0-rc.1",
-        "enhanced-resolve": "5.12.0",
-        "fast-querystring": "1.1.2",
-        "graceful-fs": "4.2.10",
-        "json-parse-even-better-errors": "^3.0.0",
-        "neo-async": "2.6.2",
-        "react-refresh": "0.14.0",
-        "tapable": "2.2.1",
-        "terminal-link": "^2.1.1",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "3.2.3",
-        "zod": "^3.21.4",
-        "zod-validation-error": "1.2.0"
       }
     },
     "node_modules/@rspack/binding": {
@@ -11344,13 +11037,13 @@
       }
     },
     "@rsbuild/core": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.23.tgz",
-      "integrity": "sha512-NnmCl58FiXofFLvjCwXiKF8dDVmcnG08/iozvEeMW4QQmaWwTigZ7DUB0VCHWH+bjCQopYpFdk3UMH0aLIi73g==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
+      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
       "dev": true,
       "requires": {
-        "@rsbuild/shared": "0.0.23",
-        "@rspack/core": "0.3.12",
+        "@rsbuild/shared": "0.0.24",
+        "@rspack/core": "0.3.13",
         "core-js": "~3.32.2",
         "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
         "http-proxy-middleware": "^2.0.1",
@@ -11359,221 +11052,20 @@
         "semver": "^7.5.4",
         "sirv": "^2.0.3",
         "ws": "^8.2.0"
-      },
-      "dependencies": {
-        "@rspack/binding": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.12.tgz",
-          "integrity": "sha512-UC+JMLqmN9IBfk6PIjH5LW+/XlESCXAV1L1Sdtiwagjp2O5ES/vRYb7j8InqXk87o30drCtdC0igZColSiX/tQ==",
-          "dev": true,
-          "requires": {
-            "@rspack/binding-darwin-arm64": "0.3.12",
-            "@rspack/binding-darwin-x64": "0.3.12",
-            "@rspack/binding-linux-arm64-gnu": "0.3.12",
-            "@rspack/binding-linux-arm64-musl": "0.3.12",
-            "@rspack/binding-linux-x64-gnu": "0.3.12",
-            "@rspack/binding-linux-x64-musl": "0.3.12",
-            "@rspack/binding-win32-arm64-msvc": "0.3.12",
-            "@rspack/binding-win32-ia32-msvc": "0.3.12",
-            "@rspack/binding-win32-x64-msvc": "0.3.12"
-          }
-        },
-        "@rspack/binding-darwin-arm64": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.12.tgz",
-          "integrity": "sha512-ObnwLPnN4ylD7sTkm6foRHZEX0y+tJTssDX5kebrGSCMaW68OT4JFacmI/3HOQemJEgyL9m5Bp3I7kithzMOtA==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-darwin-x64": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.12.tgz",
-          "integrity": "sha512-WYFNDUcIeg+4s3aJ0FtwmqR94MbeyIKYfNgZ0LJf+cmCZHRVtizyxiUm5hsWJpEhBWKGzcMXPvykc5LyjJ6YRw==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-linux-arm64-gnu": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.12.tgz",
-          "integrity": "sha512-6mTBtkpprRiUTO1D84yZtOTmSLkGtTfD79jkBkQ8UHjyXas7NWJHCMVNcBK417NcAJ6jxfGVXZrp7e1ERTfFfw==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-linux-arm64-musl": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.12.tgz",
-          "integrity": "sha512-jvTjx8KDkkRuGTI43PBUtfft1JfpLO41xyd8q4teFkSmZ54xhgBwyph3k7NCK+MP3rMwiNhFJLphObpQfU/djg==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-linux-x64-gnu": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.12.tgz",
-          "integrity": "sha512-nbFJgAh97iirsRlRFXLkWFolqdnJ9vo9mRc+EpH2pvbY/FDSUgAXfzIfbKAoN+Ll4UzlqMUOa6v+WZ3VOcMCeg==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-linux-x64-musl": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.12.tgz",
-          "integrity": "sha512-yuYD5Vj/H9O66/L2CgnILqkaEpN4ZWTxmYNKOpEm+IxEuOYuMX9aDkY6ks9Qhkb1+iOK9SrruZ7BGd0avUnMUg==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-win32-arm64-msvc": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.12.tgz",
-          "integrity": "sha512-lHpt54ci90ahwD3YujcA+KZmkqjhTA/+kfTknYxiIzC+25pn+fY8cAvlieZT7lgZeglf8I2GyLTywjUV+D75ng==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-win32-ia32-msvc": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.12.tgz",
-          "integrity": "sha512-9aU4LmNVLDOumcruOvv1+y6XgNP8SCVreCY27wohrj2ISkG3JPQvJo3hkHOqo5xU1ZQlvdauGI7rXL8rBqV7vA==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/binding-win32-x64-msvc": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.12.tgz",
-          "integrity": "sha512-KckmVXMVW9sCifqR3tOatPM9YrP8ylH53NgcgqvaKnkAadK5kcT/y0u2gM54ThM9eA0oi0PDoCJARTDRbxRjGQ==",
-          "dev": true,
-          "optional": true
-        },
-        "@rspack/core": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.12.tgz",
-          "integrity": "sha512-61my6rVPLYSmouzZBs6SeUJEUZCOsHLOJlrs+Gj90tZfEv2YtZX3uj3Kqeiitx6NrFoQUz9/aD9UJB+5eJ2Dsw==",
-          "dev": true,
-          "requires": {
-            "@rspack/binding": "0.3.12",
-            "@swc/helpers": "0.5.1",
-            "browserslist": "^4.21.3",
-            "compare-versions": "6.0.0-rc.1",
-            "enhanced-resolve": "5.12.0",
-            "fast-querystring": "1.1.2",
-            "graceful-fs": "4.2.10",
-            "json-parse-even-better-errors": "^3.0.0",
-            "neo-async": "2.6.2",
-            "react-refresh": "0.14.0",
-            "tapable": "2.2.1",
-            "terminal-link": "^2.1.1",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "3.2.3",
-            "zod": "^3.21.4",
-            "zod-validation-error": "1.2.0"
-          }
-        }
       }
     },
     "@rsbuild/shared": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.23.tgz",
-      "integrity": "sha512-VFwTbAAMx+OePQtmrPs2ocRSKpCsyxoyt5FrnhxWIGw+viVdTKuE4HONIPb2KpmP3lUfpo0aDRhrm9TEnUmnUA==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.24.tgz",
+      "integrity": "sha512-xfLPZE1arTlgiKQVQfplCCYkp32j5l7vApOqDdzfjoCDpmQa9pcw6sRThrdzfpkrY2zkGZ5tc/9LICKH0C/Ezg==",
       "requires": {
-        "@rspack/core": "0.3.12",
+        "@rspack/core": "0.3.13",
         "caniuse-lite": "^1.0.30001559",
         "json5": "^2.2.3",
         "line-diff": "2.1.1",
         "lodash": "^4.17.21",
         "postcss": "8.4.31",
         "semver": "^7.5.4"
-      },
-      "dependencies": {
-        "@rspack/binding": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.12.tgz",
-          "integrity": "sha512-UC+JMLqmN9IBfk6PIjH5LW+/XlESCXAV1L1Sdtiwagjp2O5ES/vRYb7j8InqXk87o30drCtdC0igZColSiX/tQ==",
-          "requires": {
-            "@rspack/binding-darwin-arm64": "0.3.12",
-            "@rspack/binding-darwin-x64": "0.3.12",
-            "@rspack/binding-linux-arm64-gnu": "0.3.12",
-            "@rspack/binding-linux-arm64-musl": "0.3.12",
-            "@rspack/binding-linux-x64-gnu": "0.3.12",
-            "@rspack/binding-linux-x64-musl": "0.3.12",
-            "@rspack/binding-win32-arm64-msvc": "0.3.12",
-            "@rspack/binding-win32-ia32-msvc": "0.3.12",
-            "@rspack/binding-win32-x64-msvc": "0.3.12"
-          }
-        },
-        "@rspack/binding-darwin-arm64": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.12.tgz",
-          "integrity": "sha512-ObnwLPnN4ylD7sTkm6foRHZEX0y+tJTssDX5kebrGSCMaW68OT4JFacmI/3HOQemJEgyL9m5Bp3I7kithzMOtA==",
-          "optional": true
-        },
-        "@rspack/binding-darwin-x64": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.12.tgz",
-          "integrity": "sha512-WYFNDUcIeg+4s3aJ0FtwmqR94MbeyIKYfNgZ0LJf+cmCZHRVtizyxiUm5hsWJpEhBWKGzcMXPvykc5LyjJ6YRw==",
-          "optional": true
-        },
-        "@rspack/binding-linux-arm64-gnu": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.12.tgz",
-          "integrity": "sha512-6mTBtkpprRiUTO1D84yZtOTmSLkGtTfD79jkBkQ8UHjyXas7NWJHCMVNcBK417NcAJ6jxfGVXZrp7e1ERTfFfw==",
-          "optional": true
-        },
-        "@rspack/binding-linux-arm64-musl": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.12.tgz",
-          "integrity": "sha512-jvTjx8KDkkRuGTI43PBUtfft1JfpLO41xyd8q4teFkSmZ54xhgBwyph3k7NCK+MP3rMwiNhFJLphObpQfU/djg==",
-          "optional": true
-        },
-        "@rspack/binding-linux-x64-gnu": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.12.tgz",
-          "integrity": "sha512-nbFJgAh97iirsRlRFXLkWFolqdnJ9vo9mRc+EpH2pvbY/FDSUgAXfzIfbKAoN+Ll4UzlqMUOa6v+WZ3VOcMCeg==",
-          "optional": true
-        },
-        "@rspack/binding-linux-x64-musl": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.12.tgz",
-          "integrity": "sha512-yuYD5Vj/H9O66/L2CgnILqkaEpN4ZWTxmYNKOpEm+IxEuOYuMX9aDkY6ks9Qhkb1+iOK9SrruZ7BGd0avUnMUg==",
-          "optional": true
-        },
-        "@rspack/binding-win32-arm64-msvc": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.12.tgz",
-          "integrity": "sha512-lHpt54ci90ahwD3YujcA+KZmkqjhTA/+kfTknYxiIzC+25pn+fY8cAvlieZT7lgZeglf8I2GyLTywjUV+D75ng==",
-          "optional": true
-        },
-        "@rspack/binding-win32-ia32-msvc": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.12.tgz",
-          "integrity": "sha512-9aU4LmNVLDOumcruOvv1+y6XgNP8SCVreCY27wohrj2ISkG3JPQvJo3hkHOqo5xU1ZQlvdauGI7rXL8rBqV7vA==",
-          "optional": true
-        },
-        "@rspack/binding-win32-x64-msvc": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.12.tgz",
-          "integrity": "sha512-KckmVXMVW9sCifqR3tOatPM9YrP8ylH53NgcgqvaKnkAadK5kcT/y0u2gM54ThM9eA0oi0PDoCJARTDRbxRjGQ==",
-          "optional": true
-        },
-        "@rspack/core": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.12.tgz",
-          "integrity": "sha512-61my6rVPLYSmouzZBs6SeUJEUZCOsHLOJlrs+Gj90tZfEv2YtZX3uj3Kqeiitx6NrFoQUz9/aD9UJB+5eJ2Dsw==",
-          "requires": {
-            "@rspack/binding": "0.3.12",
-            "@swc/helpers": "0.5.1",
-            "browserslist": "^4.21.3",
-            "compare-versions": "6.0.0-rc.1",
-            "enhanced-resolve": "5.12.0",
-            "fast-querystring": "1.1.2",
-            "graceful-fs": "4.2.10",
-            "json-parse-even-better-errors": "^3.0.0",
-            "neo-async": "2.6.2",
-            "react-refresh": "0.14.0",
-            "tapable": "2.2.1",
-            "terminal-link": "^2.1.1",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "3.2.3",
-            "zod": "^3.21.4",
-            "zod-validation-error": "1.2.0"
-          }
-        }
       }
     },
     "@rspack/binding": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,7 +9,7 @@
     "build": "node ./build.mjs"
   },
   "devDependencies": {
-    "@rsbuild/core": "^0.0.23",
+    "@rsbuild/core": "^0.0.24",
     "@types/node": "^20.9.0",
     "ts-node": "^10.9.1"
   },
@@ -17,7 +17,7 @@
     "@remix-run/dev": "^2.2.0",
     "@remix-run/node": "^2.2.0",
     "@remix-run/react": "^2.2.0",
-    "@rsbuild/shared": "^0.0.23",
+    "@rsbuild/shared": "^0.0.24",
     "@rspack/cli": "^0.3.13",
     "@rspack/core": "^0.3.13",
     "isbot": "latest"

--- a/playground/rsbuild.config.mjs
+++ b/playground/rsbuild.config.mjs
@@ -16,9 +16,6 @@ const defaultDistPath = {
   worker: 'worker',
 };
 export default defineConfig({
-  source:{
-    entry: {},
-  },
   // output:{
   //   distPath:defaultDistPath
   // },

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -17,7 +17,6 @@ export const pluginFoo = (remixOptions = {}) => ({
         setConfig(config,'output.distPath.root', path.basename(remixConfig.serverBuildPath));
       } else {
         setConfig(config, 'output.distPath.root',remixConfig.relativeAssetsBuildDirectory);
-        console.log(config.output.distPath);
       }
 
       return config
@@ -31,7 +30,6 @@ export const pluginFoo = (remixOptions = {}) => ({
         };
         setConfig(config, 'target', 'web');
         setConfig(config, 'name', 'browser');
-        // setConfig(config, 'output.path', remixConfig.assetsBuildDirectory);
         setConfig(config, 'output.publicPath', 'auto');
         setConfig(config, 'output.module', true);
         setConfig(config, 'output.library', { type: 'module' });


### PR DESCRIPTION
Bump Rsbuild 0.0.24 to fix some issues, such as:

- fix: should not print entry error when entry is set by plugins
- fix: context should be updated after modifyRsbuildConfig hook
- fix: should register config.plugins when using JavaScript API

Full changelog: https://github.com/web-infra-dev/rsbuild/releases/tag/v0.0.24