### PR TITLE
fix: make dev server works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-rsbuild",
+  "name": "remix",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -9,8 +9,8 @@
         "webpack-node-externals": "^3.0.0"
       },
       "devDependencies": {
-        "@rsbuild/core": "^0.0.24",
-        "@rsbuild/shared": "^0.0.24"
+        "@rsbuild/core": "^0.0.28",
+        "@rsbuild/shared": "^0.0.28"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -343,85 +343,18 @@
         "node": ">=12"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.23",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
-      "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
-      "dev": true
-    },
     "node_modules/@rsbuild/core": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
-      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.28.tgz",
+      "integrity": "sha512-dCdV2K2zWwy07RrmUoOLEen8NFHmggNYdY67JAcbGGHpymj1EeyPf1Nq/t5tY7sbP9XDtdrNuLX3XA6BzxEKcA==",
       "dev": true,
       "dependencies": {
-        "@rsbuild/shared": "0.0.24",
-        "@rspack/core": "0.3.13",
+        "@rsbuild/shared": "0.0.28",
+        "@rspack/core": "0.3.14",
         "core-js": "~3.32.2",
-        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
-        "http-proxy-middleware": "^2.0.1",
-        "jiti": "^1.20.0",
+        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
         "postcss": "8.4.31",
         "semver": "^7.5.4",
-        "sirv": "^2.0.3",
         "ws": "^8.2.0"
       },
       "bin": {
@@ -432,41 +365,39 @@
       }
     },
     "node_modules/@rsbuild/shared": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.24.tgz",
-      "integrity": "sha512-xfLPZE1arTlgiKQVQfplCCYkp32j5l7vApOqDdzfjoCDpmQa9pcw6sRThrdzfpkrY2zkGZ5tc/9LICKH0C/Ezg==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.28.tgz",
+      "integrity": "sha512-UPTGkiAm2DNlNmrhnQZTlTYcHb63aWY5fmQIZ4hTgfTAl991ldS9Z7Tq0dGEmuZng5pJ5dHbBUXHQGTzKq9wxA==",
       "dev": true,
       "dependencies": {
-        "@rspack/core": "0.3.13",
+        "@rspack/core": "0.3.14",
         "caniuse-lite": "^1.0.30001559",
-        "json5": "^2.2.3",
         "line-diff": "2.1.1",
         "lodash": "^4.17.21",
-        "postcss": "8.4.31",
-        "semver": "^7.5.4"
+        "postcss": "8.4.31"
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.13.tgz",
-      "integrity": "sha512-4ZktTw7IxE7XR4JwKlja08jww4u3FyzT2YxPpykPvUupR69zjkznXKJX4IZ8LVXbc/hKCdrULtaUKlfT+9ir1Q==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.14.tgz",
+      "integrity": "sha512-kcbhfvrXqxf2NQsidnRxZ4ab/Vvxm2timNZIWu5BgXi8hPAXayG+JyDEQMVC0xj5qlDrJid+z7J4U0IIHi5RrQ==",
       "dev": true,
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "0.3.13",
-        "@rspack/binding-darwin-x64": "0.3.13",
-        "@rspack/binding-linux-arm64-gnu": "0.3.13",
-        "@rspack/binding-linux-arm64-musl": "0.3.13",
-        "@rspack/binding-linux-x64-gnu": "0.3.13",
-        "@rspack/binding-linux-x64-musl": "0.3.13",
-        "@rspack/binding-win32-arm64-msvc": "0.3.13",
-        "@rspack/binding-win32-ia32-msvc": "0.3.13",
-        "@rspack/binding-win32-x64-msvc": "0.3.13"
+        "@rspack/binding-darwin-arm64": "0.3.14",
+        "@rspack/binding-darwin-x64": "0.3.14",
+        "@rspack/binding-linux-arm64-gnu": "0.3.14",
+        "@rspack/binding-linux-arm64-musl": "0.3.14",
+        "@rspack/binding-linux-x64-gnu": "0.3.14",
+        "@rspack/binding-linux-x64-musl": "0.3.14",
+        "@rspack/binding-win32-arm64-msvc": "0.3.14",
+        "@rspack/binding-win32-ia32-msvc": "0.3.14",
+        "@rspack/binding-win32-x64-msvc": "0.3.14"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.13.tgz",
-      "integrity": "sha512-mXAmBn+cvG1o5p8F3IYIq9Mn4g1u/xGY++MwuAtWMwx7IFrZR+94j9W9K4JKGfixiuUFB2FsVOT5AdxWiqTO5w==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.14.tgz",
+      "integrity": "sha512-mUljW63ljx7gDn8ZFov+7AHTbQ6afU7CGwQFdpyoBW8XKFdHz6DPBllpMq5mMv2gDhQdpJUhdU0b/fNDl7d9QQ==",
       "cpu": [
         "arm64"
       ],
@@ -477,9 +408,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.13.tgz",
-      "integrity": "sha512-l55X39ZrF8V90V4vpbDkXi103L8XSDMgS26XYhy5TqSSaqRlImaoaVDOxIjREWtR1MmuUf+BlLlXvu/DtR4wTw==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.14.tgz",
+      "integrity": "sha512-3/TplaFuUfukvR+50xHdAkRRAjZWuT4+V4xn8puel22Qx53gGi2Bh6pdAKXDDeoSEvF2bozrOeKZm04lPaAQOQ==",
       "cpu": [
         "x64"
       ],
@@ -490,9 +421,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.13.tgz",
-      "integrity": "sha512-AQx0PaeYcq+k1A3wmHsgZNN5qkGv2a5dUwTSK53DIn0e5tTIZQNKSllBRUyDKrV2TQcvFRJxm/t5MIj7CxgUIg==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.14.tgz",
+      "integrity": "sha512-HPTWqZZlPsjS489ByX8RtgYoodn4IcSFrdTdi8gyLCKNfq7hf7uwWP5/dJQK/EW+wVch8HkrOJECxdXHRCDFIg==",
       "cpu": [
         "arm64"
       ],
@@ -503,9 +434,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.13.tgz",
-      "integrity": "sha512-FvPAERun7iLiNd9vKEpP9d1q26GDk9sqc7hr2qG3A28VX32BfyB2C6vqe2UxZtxut9ETbbSzAFeDAvctZnXfkg==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.14.tgz",
+      "integrity": "sha512-8d0VFLlUatZJp/Z/udpV7kW3g3Uyrenr5bu6w5oETIv7Bv1T6IR3as7R0s2dONa7JkuAw4gQB0c1k9X44SxoBQ==",
       "cpu": [
         "arm64"
       ],
@@ -516,9 +447,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.13.tgz",
-      "integrity": "sha512-Bss5h5YenETDn7CiXlTSb7vNEUEHGiLOjO5YbozUEEnvlLRHJemh2bFLyv2k/wEpkgi+ZkSyKWw6ESHTfXfadQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.14.tgz",
+      "integrity": "sha512-Hy7z+orffDzQ5Jt3CSF9kncCPPGWyDS6Bs4FgSbYiOgoB314tdpgBSkdrh6wiG5inXLbOFI5Mc3Gct5hK0ok/w==",
       "cpu": [
         "x64"
       ],
@@ -529,9 +460,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.13.tgz",
-      "integrity": "sha512-treRV2h5g4+PSdCpnX9cSttWm9r+JtS7NrlYLF/5OcBhI8NGC/vex9wMObz1fCKiuHD/l1IPxqfeZN6JRz3sEA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.14.tgz",
+      "integrity": "sha512-m/DEip/dJhUuFCLZggOllBAHsRtBmUfRk/YyzxaHLNEImR7/ZV2SIEU1krnicNsz5pO8pQ7mjPeFpio/XsHciQ==",
       "cpu": [
         "x64"
       ],
@@ -542,9 +473,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.13.tgz",
-      "integrity": "sha512-aIOAYsDGxQrK2cIOAqx1LLXQZcid9s1GgZ842Knas2jlBap2DtWNg3qoULBkVg0eHiLlYd7Sfe7wGjiQF/2UiA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.14.tgz",
+      "integrity": "sha512-Mpj5on9HWHcQ2BnAXWm/OhwbrEtNYSr3Ab1v/0sGxFdufcqI5u7xRjFlLbgEUDmDb4Cfr4/VoWMvAKCIsilc6A==",
       "cpu": [
         "arm64"
       ],
@@ -555,9 +486,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.13.tgz",
-      "integrity": "sha512-OWP9GLJYxawTJ/dZnAO1YWmgLR9hScRmUZeCAbhCGD5niGBBke7IZWLi1Yk3AvZFXcUi/DAKiXCrSj7d1HvOHg==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.14.tgz",
+      "integrity": "sha512-JwMCL+l2UicDPgQG6GCtDfxjahcCIMyWc+CCvFH9BeI4/XWU6O6m1kXbJfx0qLXRWAZQhALlpW9o8BE8Sr73dg==",
       "cpu": [
         "ia32"
       ],
@@ -568,9 +499,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.13.tgz",
-      "integrity": "sha512-/FY3w+IGMYvCCl5WV+IZQNieeC0d2SNA2xpsEUHp57JbXbP5TQBcIaMpPXLOw3Be67qsehmbAcpJkMaFR2/3EA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.14.tgz",
+      "integrity": "sha512-QqcPv2II8YTRybuhMCnJXlz7xIvknwyaIlhflDcC2hNBGIo8H866A66cMY/r3bDVcrrVpgx79yFeJ+a/pyjdHQ==",
       "cpu": [
         "x64"
       ],
@@ -581,12 +512,12 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.13.tgz",
-      "integrity": "sha512-YCJ1d4HGj/MVkm/JDQwTFFKd2/tjJwAok1FLR5nBLN4AfDBlv9cwB3QhM3ZTNvECmk/Gk7esDsCQpI3Gt1rNkA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.14.tgz",
+      "integrity": "sha512-B76vRdbKXMi/Xjd8Q0f/4xrlqp4mFELH2w+6ROoAscGVgS8eDsWmJHa7ddIB3FELizzDvI3BjGfBeGftZjSg3g==",
       "dev": true,
       "dependencies": {
-        "@rspack/binding": "0.3.13",
+        "@rspack/binding": "0.3.14",
         "@swc/helpers": "0.5.1",
         "browserslist": "^4.21.3",
         "compare-versions": "6.0.0-rc.1",
@@ -613,36 +544,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.14",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -656,18 +557,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -702,26 +591,10 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001562",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
-      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
+      "version": "1.0.30001563",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
+      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
       "dev": true,
       "funding": [
         {
@@ -737,27 +610,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/clean-css": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
-      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/compare-versions": {
       "version": "6.0.0-rc.1",
@@ -776,20 +628,10 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.585",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.585.tgz",
-      "integrity": "sha512-B4yBlX0azdA3rVMxpYwLQfDpdwOgcnLCkpvSOd68iFmeedo+WYjaBJS3/W58LVD8CB2nf+o7C4K9xz1l09RkWg==",
+      "version": "1.4.589",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.589.tgz",
+      "integrity": "sha512-zF6y5v/YfoFIgwf2dDfAqVlPPsyQeWNpEWXbAlDUS8Ax4Z2VoiiZpAPC0Jm9hXEkJm2vIZpwB6rc4KnLTQffbQ==",
       "dev": true
     },
     "node_modules/enhanced-resolve": {
@@ -803,18 +645,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -862,12 +692,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
-    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -881,38 +705,6 @@
       "dev": true,
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/glob-to-regexp": {
@@ -936,35 +728,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dev": true,
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/html-webpack-plugin": {
       "name": "html-rspack-plugin",
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.5.tgz",
-      "integrity": "sha512-IXwQK2HcH2GYdqlW4lwzhXStXNqhvOjd0fwOto7H4wBE+xN8F2b9aVCR2zkhxTxs1G09b4tBqehD7cOWiAhNeQ==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.7.tgz",
+      "integrity": "sha512-7dNAURj9XBHWoYg59F8VU6hT7J7w+od4Lr5hc/rrgN6sy6QfqVpoPqW9Qw4IGFOgit8Pul7iQp1yysBSIhOlsg==",
       "dev": true,
       "dependencies": {
-        "html-minifier-terser": "^7.2.0",
         "lodash": "^4.17.21",
         "tapable": "^2.0.0"
       },
@@ -976,95 +746,6 @@
         "url": "https://opencollective.com/html-webpack-plugin"
       }
     },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
-      "dev": true,
-      "dependencies": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
@@ -1072,18 +753,6 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/levdist": {
@@ -1107,15 +776,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1124,28 +784,6 @@
       "dependencies": {
         "yallist": "^4.0.0"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/mrmime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -1174,59 +812,17 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",
@@ -1265,21 +861,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
-    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -1295,29 +876,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/sirv": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
-      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
-      "dev": true,
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.20",
-        "mrmime": "^1.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -1325,16 +883,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/supports-color": {
@@ -1387,51 +935,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/terser": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
-      "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -1449,12 +952,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -1698,181 +1195,121 @@
       "integrity": "sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==",
       "optional": true
     },
-    "@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true
-    },
-    "@jridgewell/source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "@polka/url": {
-      "version": "1.0.0-next.23",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
-      "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
-      "dev": true
-    },
     "@rsbuild/core": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
-      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.28.tgz",
+      "integrity": "sha512-dCdV2K2zWwy07RrmUoOLEen8NFHmggNYdY67JAcbGGHpymj1EeyPf1Nq/t5tY7sbP9XDtdrNuLX3XA6BzxEKcA==",
       "dev": true,
       "requires": {
-        "@rsbuild/shared": "0.0.24",
-        "@rspack/core": "0.3.13",
+        "@rsbuild/shared": "0.0.28",
+        "@rspack/core": "0.3.14",
         "core-js": "~3.32.2",
-        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
-        "http-proxy-middleware": "^2.0.1",
-        "jiti": "^1.20.0",
+        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
         "postcss": "8.4.31",
         "semver": "^7.5.4",
-        "sirv": "^2.0.3",
         "ws": "^8.2.0"
       }
     },
     "@rsbuild/shared": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.24.tgz",
-      "integrity": "sha512-xfLPZE1arTlgiKQVQfplCCYkp32j5l7vApOqDdzfjoCDpmQa9pcw6sRThrdzfpkrY2zkGZ5tc/9LICKH0C/Ezg==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.28.tgz",
+      "integrity": "sha512-UPTGkiAm2DNlNmrhnQZTlTYcHb63aWY5fmQIZ4hTgfTAl991ldS9Z7Tq0dGEmuZng5pJ5dHbBUXHQGTzKq9wxA==",
       "dev": true,
       "requires": {
-        "@rspack/core": "0.3.13",
+        "@rspack/core": "0.3.14",
         "caniuse-lite": "^1.0.30001559",
-        "json5": "^2.2.3",
         "line-diff": "2.1.1",
         "lodash": "^4.17.21",
-        "postcss": "8.4.31",
-        "semver": "^7.5.4"
+        "postcss": "8.4.31"
       }
     },
     "@rspack/binding": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.13.tgz",
-      "integrity": "sha512-4ZktTw7IxE7XR4JwKlja08jww4u3FyzT2YxPpykPvUupR69zjkznXKJX4IZ8LVXbc/hKCdrULtaUKlfT+9ir1Q==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.14.tgz",
+      "integrity": "sha512-kcbhfvrXqxf2NQsidnRxZ4ab/Vvxm2timNZIWu5BgXi8hPAXayG+JyDEQMVC0xj5qlDrJid+z7J4U0IIHi5RrQ==",
       "dev": true,
       "requires": {
-        "@rspack/binding-darwin-arm64": "0.3.13",
-        "@rspack/binding-darwin-x64": "0.3.13",
-        "@rspack/binding-linux-arm64-gnu": "0.3.13",
-        "@rspack/binding-linux-arm64-musl": "0.3.13",
-        "@rspack/binding-linux-x64-gnu": "0.3.13",
-        "@rspack/binding-linux-x64-musl": "0.3.13",
-        "@rspack/binding-win32-arm64-msvc": "0.3.13",
-        "@rspack/binding-win32-ia32-msvc": "0.3.13",
-        "@rspack/binding-win32-x64-msvc": "0.3.13"
+        "@rspack/binding-darwin-arm64": "0.3.14",
+        "@rspack/binding-darwin-x64": "0.3.14",
+        "@rspack/binding-linux-arm64-gnu": "0.3.14",
+        "@rspack/binding-linux-arm64-musl": "0.3.14",
+        "@rspack/binding-linux-x64-gnu": "0.3.14",
+        "@rspack/binding-linux-x64-musl": "0.3.14",
+        "@rspack/binding-win32-arm64-msvc": "0.3.14",
+        "@rspack/binding-win32-ia32-msvc": "0.3.14",
+        "@rspack/binding-win32-x64-msvc": "0.3.14"
       }
     },
     "@rspack/binding-darwin-arm64": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.13.tgz",
-      "integrity": "sha512-mXAmBn+cvG1o5p8F3IYIq9Mn4g1u/xGY++MwuAtWMwx7IFrZR+94j9W9K4JKGfixiuUFB2FsVOT5AdxWiqTO5w==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.14.tgz",
+      "integrity": "sha512-mUljW63ljx7gDn8ZFov+7AHTbQ6afU7CGwQFdpyoBW8XKFdHz6DPBllpMq5mMv2gDhQdpJUhdU0b/fNDl7d9QQ==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-darwin-x64": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.13.tgz",
-      "integrity": "sha512-l55X39ZrF8V90V4vpbDkXi103L8XSDMgS26XYhy5TqSSaqRlImaoaVDOxIjREWtR1MmuUf+BlLlXvu/DtR4wTw==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.14.tgz",
+      "integrity": "sha512-3/TplaFuUfukvR+50xHdAkRRAjZWuT4+V4xn8puel22Qx53gGi2Bh6pdAKXDDeoSEvF2bozrOeKZm04lPaAQOQ==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-arm64-gnu": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.13.tgz",
-      "integrity": "sha512-AQx0PaeYcq+k1A3wmHsgZNN5qkGv2a5dUwTSK53DIn0e5tTIZQNKSllBRUyDKrV2TQcvFRJxm/t5MIj7CxgUIg==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.14.tgz",
+      "integrity": "sha512-HPTWqZZlPsjS489ByX8RtgYoodn4IcSFrdTdi8gyLCKNfq7hf7uwWP5/dJQK/EW+wVch8HkrOJECxdXHRCDFIg==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-arm64-musl": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.13.tgz",
-      "integrity": "sha512-FvPAERun7iLiNd9vKEpP9d1q26GDk9sqc7hr2qG3A28VX32BfyB2C6vqe2UxZtxut9ETbbSzAFeDAvctZnXfkg==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.14.tgz",
+      "integrity": "sha512-8d0VFLlUatZJp/Z/udpV7kW3g3Uyrenr5bu6w5oETIv7Bv1T6IR3as7R0s2dONa7JkuAw4gQB0c1k9X44SxoBQ==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-x64-gnu": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.13.tgz",
-      "integrity": "sha512-Bss5h5YenETDn7CiXlTSb7vNEUEHGiLOjO5YbozUEEnvlLRHJemh2bFLyv2k/wEpkgi+ZkSyKWw6ESHTfXfadQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.14.tgz",
+      "integrity": "sha512-Hy7z+orffDzQ5Jt3CSF9kncCPPGWyDS6Bs4FgSbYiOgoB314tdpgBSkdrh6wiG5inXLbOFI5Mc3Gct5hK0ok/w==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-linux-x64-musl": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.13.tgz",
-      "integrity": "sha512-treRV2h5g4+PSdCpnX9cSttWm9r+JtS7NrlYLF/5OcBhI8NGC/vex9wMObz1fCKiuHD/l1IPxqfeZN6JRz3sEA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.14.tgz",
+      "integrity": "sha512-m/DEip/dJhUuFCLZggOllBAHsRtBmUfRk/YyzxaHLNEImR7/ZV2SIEU1krnicNsz5pO8pQ7mjPeFpio/XsHciQ==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-win32-arm64-msvc": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.13.tgz",
-      "integrity": "sha512-aIOAYsDGxQrK2cIOAqx1LLXQZcid9s1GgZ842Knas2jlBap2DtWNg3qoULBkVg0eHiLlYd7Sfe7wGjiQF/2UiA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.14.tgz",
+      "integrity": "sha512-Mpj5on9HWHcQ2BnAXWm/OhwbrEtNYSr3Ab1v/0sGxFdufcqI5u7xRjFlLbgEUDmDb4Cfr4/VoWMvAKCIsilc6A==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-win32-ia32-msvc": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.13.tgz",
-      "integrity": "sha512-OWP9GLJYxawTJ/dZnAO1YWmgLR9hScRmUZeCAbhCGD5niGBBke7IZWLi1Yk3AvZFXcUi/DAKiXCrSj7d1HvOHg==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.14.tgz",
+      "integrity": "sha512-JwMCL+l2UicDPgQG6GCtDfxjahcCIMyWc+CCvFH9BeI4/XWU6O6m1kXbJfx0qLXRWAZQhALlpW9o8BE8Sr73dg==",
       "dev": true,
       "optional": true
     },
     "@rspack/binding-win32-x64-msvc": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.13.tgz",
-      "integrity": "sha512-/FY3w+IGMYvCCl5WV+IZQNieeC0d2SNA2xpsEUHp57JbXbP5TQBcIaMpPXLOw3Be67qsehmbAcpJkMaFR2/3EA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.14.tgz",
+      "integrity": "sha512-QqcPv2II8YTRybuhMCnJXlz7xIvknwyaIlhflDcC2hNBGIo8H866A66cMY/r3bDVcrrVpgx79yFeJ+a/pyjdHQ==",
       "dev": true,
       "optional": true
     },
     "@rspack/core": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.13.tgz",
-      "integrity": "sha512-YCJ1d4HGj/MVkm/JDQwTFFKd2/tjJwAok1FLR5nBLN4AfDBlv9cwB3QhM3ZTNvECmk/Gk7esDsCQpI3Gt1rNkA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.14.tgz",
+      "integrity": "sha512-B76vRdbKXMi/Xjd8Q0f/4xrlqp4mFELH2w+6ROoAscGVgS8eDsWmJHa7ddIB3FELizzDvI3BjGfBeGftZjSg3g==",
       "dev": true,
       "requires": {
-        "@rspack/binding": "0.3.13",
+        "@rspack/binding": "0.3.14",
         "@swc/helpers": "0.5.1",
         "browserslist": "^4.21.3",
         "compare-versions": "6.0.0-rc.1",
@@ -1899,30 +1336,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "@types/http-proxy": {
-      "version": "1.17.14",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
-      "dev": true,
-      "requires": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1930,15 +1343,6 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
-      }
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "requires": {
-        "fill-range": "^7.0.1"
       }
     },
     "browserslist": {
@@ -1953,41 +1357,10 @@
         "update-browserslist-db": "^1.0.13"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
-    "camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "caniuse-lite": {
-      "version": "1.0.30001562",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
-      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
-      "dev": true
-    },
-    "clean-css": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
-      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
-      "dev": true,
-      "requires": {
-        "source-map": "~0.6.0"
-      }
-    },
-    "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "1.0.30001563",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
+      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
       "dev": true
     },
     "compare-versions": {
@@ -2002,20 +1375,10 @@
       "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
       "dev": true
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "electron-to-chromium": {
-      "version": "1.4.585",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.585.tgz",
-      "integrity": "sha512-B4yBlX0azdA3rVMxpYwLQfDpdwOgcnLCkpvSOd68iFmeedo+WYjaBJS3/W58LVD8CB2nf+o7C4K9xz1l09RkWg==",
+      "version": "1.4.589",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.589.tgz",
+      "integrity": "sha512-zF6y5v/YfoFIgwf2dDfAqVlPPsyQeWNpEWXbAlDUS8Ax4Z2VoiiZpAPC0Jm9hXEkJm2vIZpwB6rc4KnLTQffbQ==",
       "dev": true
     },
     "enhanced-resolve": {
@@ -2027,12 +1390,6 @@
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
       }
-    },
-    "entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true
     },
     "esbuild": {
       "version": "0.19.5",
@@ -2069,12 +1426,6 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
-    },
     "fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -2089,21 +1440,6 @@
       "requires": {
         "fast-decode-uri-component": "^1.0.1"
       }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true
     },
     "glob-to-regexp": {
       "version": "0.4.1",
@@ -2123,99 +1459,20 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dev": true,
-      "requires": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      }
-    },
     "html-webpack-plugin": {
-      "version": "npm:html-rspack-plugin@5.5.5",
-      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.5.tgz",
-      "integrity": "sha512-IXwQK2HcH2GYdqlW4lwzhXStXNqhvOjd0fwOto7H4wBE+xN8F2b9aVCR2zkhxTxs1G09b4tBqehD7cOWiAhNeQ==",
+      "version": "npm:html-rspack-plugin@5.5.7",
+      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.7.tgz",
+      "integrity": "sha512-7dNAURj9XBHWoYg59F8VU6hT7J7w+od4Lr5hc/rrgN6sy6QfqVpoPqW9Qw4IGFOgit8Pul7iQp1yysBSIhOlsg==",
       "dev": true,
       "requires": {
-        "html-minifier-terser": "^7.2.0",
         "lodash": "^4.17.21",
         "tapable": "^2.0.0"
       }
-    },
-    "http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      }
-    },
-    "http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
-      "dev": true,
-      "requires": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      }
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "dev": true
-    },
-    "jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
       "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
-      "dev": true
-    },
-    "json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "levdist": {
@@ -2239,15 +1496,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2256,22 +1504,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
-    },
-    "mrmime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
-      "dev": true
     },
     "nanoid": {
       "version": "3.3.7",
@@ -2285,52 +1517,16 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
-    "param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "postcss": {
@@ -2350,18 +1546,6 @@
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
     },
-    "relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
-    },
     "semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -2371,38 +1555,11 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "sirv": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
-      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
-      "dev": true,
-      "requires": {
-        "@polka/url": "^1.0.0-next.20",
-        "mrmime": "^1.0.0",
-        "totalist": "^3.0.0"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -2439,41 +1596,6 @@
         "supports-hyperlinks": "^2.0.0"
       }
     },
-    "terser": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
-      "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        }
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true
-    },
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -2484,12 +1606,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "type:": "module",
   "devDependencies": {
-    "@rsbuild/core": "^0.0.24",
-    "@rsbuild/shared": "^0.0.24"
+    "@rsbuild/core": "^0.0.28",
+    "@rsbuild/shared": "^0.0.28"
   },
   "dependencies": {
     "esbuild": "^0.19.5",

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -20,8 +20,8 @@
         "webpack-node-externals": "^3.0.0"
       },
       "devDependencies": {
-        "@rsbuild/core": "^0.0.24",
-        "@rsbuild/plugin-react": "^0.0.24",
+        "@rsbuild/core": "^0.0.28",
+        "@rsbuild/plugin-react": "^0.0.28",
         "@types/node": "^20.9.1"
       }
     },
@@ -1570,20 +1570,17 @@
       }
     },
     "node_modules/@rsbuild/core": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
-      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.28.tgz",
+      "integrity": "sha512-dCdV2K2zWwy07RrmUoOLEen8NFHmggNYdY67JAcbGGHpymj1EeyPf1Nq/t5tY7sbP9XDtdrNuLX3XA6BzxEKcA==",
       "dev": true,
       "dependencies": {
-        "@rsbuild/shared": "0.0.24",
-        "@rspack/core": "0.3.13",
+        "@rsbuild/shared": "0.0.28",
+        "@rspack/core": "0.3.14",
         "core-js": "~3.32.2",
-        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
-        "http-proxy-middleware": "^2.0.1",
-        "jiti": "^1.20.0",
+        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
         "postcss": "8.4.31",
         "semver": "^7.5.4",
-        "sirv": "^2.0.3",
         "ws": "^8.2.0"
       },
       "bin": {
@@ -1593,15 +1590,375 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rsbuild/plugin-react": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-react/-/plugin-react-0.0.24.tgz",
-      "integrity": "sha512-GnWIenfLCiZIJ3c+uGbQslpIgNgvzQ4Y7q1MeuK4ve7LRTxCMl5UhngZ2OL9/o6kR3XLl0oWLWadLR32crANAg==",
+    "node_modules/@rsbuild/core/node_modules/@rsbuild/shared": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.28.tgz",
+      "integrity": "sha512-UPTGkiAm2DNlNmrhnQZTlTYcHb63aWY5fmQIZ4hTgfTAl991ldS9Z7Tq0dGEmuZng5pJ5dHbBUXHQGTzKq9wxA==",
       "dev": true,
       "dependencies": {
-        "@rsbuild/shared": "0.0.24",
-        "@rspack/plugin-react-refresh": "0.3.13",
-        "react-refresh": "^0.14.0"
+        "@rspack/core": "0.3.14",
+        "caniuse-lite": "^1.0.30001559",
+        "line-diff": "2.1.1",
+        "lodash": "^4.17.21",
+        "postcss": "8.4.31"
+      }
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.14.tgz",
+      "integrity": "sha512-kcbhfvrXqxf2NQsidnRxZ4ab/Vvxm2timNZIWu5BgXi8hPAXayG+JyDEQMVC0xj5qlDrJid+z7J4U0IIHi5RrQ==",
+      "dev": true,
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "0.3.14",
+        "@rspack/binding-darwin-x64": "0.3.14",
+        "@rspack/binding-linux-arm64-gnu": "0.3.14",
+        "@rspack/binding-linux-arm64-musl": "0.3.14",
+        "@rspack/binding-linux-x64-gnu": "0.3.14",
+        "@rspack/binding-linux-x64-musl": "0.3.14",
+        "@rspack/binding-win32-arm64-msvc": "0.3.14",
+        "@rspack/binding-win32-ia32-msvc": "0.3.14",
+        "@rspack/binding-win32-x64-msvc": "0.3.14"
+      }
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-darwin-arm64": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.14.tgz",
+      "integrity": "sha512-mUljW63ljx7gDn8ZFov+7AHTbQ6afU7CGwQFdpyoBW8XKFdHz6DPBllpMq5mMv2gDhQdpJUhdU0b/fNDl7d9QQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-darwin-x64": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.14.tgz",
+      "integrity": "sha512-3/TplaFuUfukvR+50xHdAkRRAjZWuT4+V4xn8puel22Qx53gGi2Bh6pdAKXDDeoSEvF2bozrOeKZm04lPaAQOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.14.tgz",
+      "integrity": "sha512-HPTWqZZlPsjS489ByX8RtgYoodn4IcSFrdTdi8gyLCKNfq7hf7uwWP5/dJQK/EW+wVch8HkrOJECxdXHRCDFIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.14.tgz",
+      "integrity": "sha512-8d0VFLlUatZJp/Z/udpV7kW3g3Uyrenr5bu6w5oETIv7Bv1T6IR3as7R0s2dONa7JkuAw4gQB0c1k9X44SxoBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.14.tgz",
+      "integrity": "sha512-Hy7z+orffDzQ5Jt3CSF9kncCPPGWyDS6Bs4FgSbYiOgoB314tdpgBSkdrh6wiG5inXLbOFI5Mc3Gct5hK0ok/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.14.tgz",
+      "integrity": "sha512-m/DEip/dJhUuFCLZggOllBAHsRtBmUfRk/YyzxaHLNEImR7/ZV2SIEU1krnicNsz5pO8pQ7mjPeFpio/XsHciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.14.tgz",
+      "integrity": "sha512-Mpj5on9HWHcQ2BnAXWm/OhwbrEtNYSr3Ab1v/0sGxFdufcqI5u7xRjFlLbgEUDmDb4Cfr4/VoWMvAKCIsilc6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.14.tgz",
+      "integrity": "sha512-JwMCL+l2UicDPgQG6GCtDfxjahcCIMyWc+CCvFH9BeI4/XWU6O6m1kXbJfx0qLXRWAZQhALlpW9o8BE8Sr73dg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.14.tgz",
+      "integrity": "sha512-QqcPv2II8YTRybuhMCnJXlz7xIvknwyaIlhflDcC2hNBGIo8H866A66cMY/r3bDVcrrVpgx79yFeJ+a/pyjdHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rsbuild/core/node_modules/@rspack/core": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.14.tgz",
+      "integrity": "sha512-B76vRdbKXMi/Xjd8Q0f/4xrlqp4mFELH2w+6ROoAscGVgS8eDsWmJHa7ddIB3FELizzDvI3BjGfBeGftZjSg3g==",
+      "dev": true,
+      "dependencies": {
+        "@rspack/binding": "0.3.14",
+        "@swc/helpers": "0.5.1",
+        "browserslist": "^4.21.3",
+        "compare-versions": "6.0.0-rc.1",
+        "enhanced-resolve": "5.12.0",
+        "fast-querystring": "1.1.2",
+        "graceful-fs": "4.2.10",
+        "json-parse-even-better-errors": "^3.0.0",
+        "neo-async": "2.6.2",
+        "react-refresh": "0.14.0",
+        "tapable": "2.2.1",
+        "terminal-link": "^2.1.1",
+        "watchpack": "^2.4.0",
+        "webpack-sources": "3.2.3",
+        "zod": "^3.21.4",
+        "zod-validation-error": "1.2.0"
+      }
+    },
+    "node_modules/@rsbuild/plugin-react": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-react/-/plugin-react-0.0.28.tgz",
+      "integrity": "sha512-iaMn7h+0hFkAz2lhV6D2HykbvgrqbHqn3oTfh02LcT6+0nUd27JYh1/aHek+JUsH34BbGbw0DkTS+A/sc78aqQ==",
+      "dev": true,
+      "dependencies": {
+        "@rsbuild/shared": "0.0.28",
+        "@rspack/plugin-react-refresh": "0.3.14",
+        "react-refresh": "^0.14.0",
+        "semver": "^7.5.4"
+      }
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rsbuild/shared": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.28.tgz",
+      "integrity": "sha512-UPTGkiAm2DNlNmrhnQZTlTYcHb63aWY5fmQIZ4hTgfTAl991ldS9Z7Tq0dGEmuZng5pJ5dHbBUXHQGTzKq9wxA==",
+      "dev": true,
+      "dependencies": {
+        "@rspack/core": "0.3.14",
+        "caniuse-lite": "^1.0.30001559",
+        "line-diff": "2.1.1",
+        "lodash": "^4.17.21",
+        "postcss": "8.4.31"
+      }
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.14.tgz",
+      "integrity": "sha512-kcbhfvrXqxf2NQsidnRxZ4ab/Vvxm2timNZIWu5BgXi8hPAXayG+JyDEQMVC0xj5qlDrJid+z7J4U0IIHi5RrQ==",
+      "dev": true,
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "0.3.14",
+        "@rspack/binding-darwin-x64": "0.3.14",
+        "@rspack/binding-linux-arm64-gnu": "0.3.14",
+        "@rspack/binding-linux-arm64-musl": "0.3.14",
+        "@rspack/binding-linux-x64-gnu": "0.3.14",
+        "@rspack/binding-linux-x64-musl": "0.3.14",
+        "@rspack/binding-win32-arm64-msvc": "0.3.14",
+        "@rspack/binding-win32-ia32-msvc": "0.3.14",
+        "@rspack/binding-win32-x64-msvc": "0.3.14"
+      }
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-darwin-arm64": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.14.tgz",
+      "integrity": "sha512-mUljW63ljx7gDn8ZFov+7AHTbQ6afU7CGwQFdpyoBW8XKFdHz6DPBllpMq5mMv2gDhQdpJUhdU0b/fNDl7d9QQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-darwin-x64": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.14.tgz",
+      "integrity": "sha512-3/TplaFuUfukvR+50xHdAkRRAjZWuT4+V4xn8puel22Qx53gGi2Bh6pdAKXDDeoSEvF2bozrOeKZm04lPaAQOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.14.tgz",
+      "integrity": "sha512-HPTWqZZlPsjS489ByX8RtgYoodn4IcSFrdTdi8gyLCKNfq7hf7uwWP5/dJQK/EW+wVch8HkrOJECxdXHRCDFIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.14.tgz",
+      "integrity": "sha512-8d0VFLlUatZJp/Z/udpV7kW3g3Uyrenr5bu6w5oETIv7Bv1T6IR3as7R0s2dONa7JkuAw4gQB0c1k9X44SxoBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.14.tgz",
+      "integrity": "sha512-Hy7z+orffDzQ5Jt3CSF9kncCPPGWyDS6Bs4FgSbYiOgoB314tdpgBSkdrh6wiG5inXLbOFI5Mc3Gct5hK0ok/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.14.tgz",
+      "integrity": "sha512-m/DEip/dJhUuFCLZggOllBAHsRtBmUfRk/YyzxaHLNEImR7/ZV2SIEU1krnicNsz5pO8pQ7mjPeFpio/XsHciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.14.tgz",
+      "integrity": "sha512-Mpj5on9HWHcQ2BnAXWm/OhwbrEtNYSr3Ab1v/0sGxFdufcqI5u7xRjFlLbgEUDmDb4Cfr4/VoWMvAKCIsilc6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.14.tgz",
+      "integrity": "sha512-JwMCL+l2UicDPgQG6GCtDfxjahcCIMyWc+CCvFH9BeI4/XWU6O6m1kXbJfx0qLXRWAZQhALlpW9o8BE8Sr73dg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.14.tgz",
+      "integrity": "sha512-QqcPv2II8YTRybuhMCnJXlz7xIvknwyaIlhflDcC2hNBGIo8H866A66cMY/r3bDVcrrVpgx79yFeJ+a/pyjdHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/core": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.14.tgz",
+      "integrity": "sha512-B76vRdbKXMi/Xjd8Q0f/4xrlqp4mFELH2w+6ROoAscGVgS8eDsWmJHa7ddIB3FELizzDvI3BjGfBeGftZjSg3g==",
+      "dev": true,
+      "dependencies": {
+        "@rspack/binding": "0.3.14",
+        "@swc/helpers": "0.5.1",
+        "browserslist": "^4.21.3",
+        "compare-versions": "6.0.0-rc.1",
+        "enhanced-resolve": "5.12.0",
+        "fast-querystring": "1.1.2",
+        "graceful-fs": "4.2.10",
+        "json-parse-even-better-errors": "^3.0.0",
+        "neo-async": "2.6.2",
+        "react-refresh": "0.14.0",
+        "tapable": "2.2.1",
+        "terminal-link": "^2.1.1",
+        "watchpack": "^2.4.0",
+        "webpack-sources": "3.2.3",
+        "zod": "^3.21.4",
+        "zod-validation-error": "1.2.0"
+      }
+    },
+    "node_modules/@rsbuild/plugin-react/node_modules/@rspack/plugin-react-refresh": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-0.3.14.tgz",
+      "integrity": "sha512-xHMDOHpQdI7aTJHdVUJMDyE5KM+5bGNcDCY+kptITTrIfiL4RtpIQYa0w0kSZR+/JqgFgviZgqJLW8gnnS1b8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pmmmwh/react-refresh-webpack-plugin": "0.5.10"
+      },
+      "peerDependencies": {
+        "react-refresh": ">=0.10.0 <1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-refresh": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rsbuild/shared": {
@@ -2925,16 +3282,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001562",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
@@ -3054,18 +3401,6 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/clean-css": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
-      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
       }
     },
     "node_modules/clean-stack": {
@@ -3200,15 +3535,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/common-path-prefix": {
@@ -3573,16 +3899,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
@@ -3691,18 +4007,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/err-code": {
@@ -4630,35 +4934,13 @@
         }
       ]
     },
-    "node_modules/html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dev": true,
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/html-webpack-plugin": {
       "name": "html-rspack-plugin",
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.5.tgz",
-      "integrity": "sha512-IXwQK2HcH2GYdqlW4lwzhXStXNqhvOjd0fwOto7H4wBE+xN8F2b9aVCR2zkhxTxs1G09b4tBqehD7cOWiAhNeQ==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.7.tgz",
+      "integrity": "sha512-7dNAURj9XBHWoYg59F8VU6hT7J7w+od4Lr5hc/rrgN6sy6QfqVpoPqW9Qw4IGFOgit8Pul7iQp1yysBSIhOlsg==",
       "dev": true,
       "dependencies": {
-        "html-minifier-terser": "^7.2.0",
         "lodash": "^4.17.21",
         "tapable": "^2.0.0"
       },
@@ -5158,15 +5440,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5362,15 +5635,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/lru-cache": {
@@ -6481,16 +6745,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6802,16 +7056,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parse-entities": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
@@ -6850,16 +7094,6 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -7409,15 +7643,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
       "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/remark-frontmatter": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
@@ -7932,20 +8157,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "node_modules/sirv": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
-      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
-      "dev": true,
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.20",
-        "mrmime": "^1.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/sockjs": {
       "version": "0.3.24",
@@ -8489,15 +8700,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -11150,32 +11352,277 @@
       }
     },
     "@rsbuild/core": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.24.tgz",
-      "integrity": "sha512-91i/u+w8N5HI2d0+Ds5R9x6+4Ja0R3PuqH87n98LhwhRQzRPkMH/ZpN8xXNG+zrKgUxQQfjCfDmmgSUc/qZ4YQ==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.0.28.tgz",
+      "integrity": "sha512-dCdV2K2zWwy07RrmUoOLEen8NFHmggNYdY67JAcbGGHpymj1EeyPf1Nq/t5tY7sbP9XDtdrNuLX3XA6BzxEKcA==",
       "dev": true,
       "requires": {
-        "@rsbuild/shared": "0.0.24",
-        "@rspack/core": "0.3.13",
+        "@rsbuild/shared": "0.0.28",
+        "@rspack/core": "0.3.14",
         "core-js": "~3.32.2",
-        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
-        "http-proxy-middleware": "^2.0.1",
-        "jiti": "^1.20.0",
+        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
         "postcss": "8.4.31",
         "semver": "^7.5.4",
-        "sirv": "^2.0.3",
         "ws": "^8.2.0"
+      },
+      "dependencies": {
+        "@rsbuild/shared": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.28.tgz",
+          "integrity": "sha512-UPTGkiAm2DNlNmrhnQZTlTYcHb63aWY5fmQIZ4hTgfTAl991ldS9Z7Tq0dGEmuZng5pJ5dHbBUXHQGTzKq9wxA==",
+          "dev": true,
+          "requires": {
+            "@rspack/core": "0.3.14",
+            "caniuse-lite": "^1.0.30001559",
+            "line-diff": "2.1.1",
+            "lodash": "^4.17.21",
+            "postcss": "8.4.31"
+          }
+        },
+        "@rspack/binding": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.14.tgz",
+          "integrity": "sha512-kcbhfvrXqxf2NQsidnRxZ4ab/Vvxm2timNZIWu5BgXi8hPAXayG+JyDEQMVC0xj5qlDrJid+z7J4U0IIHi5RrQ==",
+          "dev": true,
+          "requires": {
+            "@rspack/binding-darwin-arm64": "0.3.14",
+            "@rspack/binding-darwin-x64": "0.3.14",
+            "@rspack/binding-linux-arm64-gnu": "0.3.14",
+            "@rspack/binding-linux-arm64-musl": "0.3.14",
+            "@rspack/binding-linux-x64-gnu": "0.3.14",
+            "@rspack/binding-linux-x64-musl": "0.3.14",
+            "@rspack/binding-win32-arm64-msvc": "0.3.14",
+            "@rspack/binding-win32-ia32-msvc": "0.3.14",
+            "@rspack/binding-win32-x64-msvc": "0.3.14"
+          }
+        },
+        "@rspack/binding-darwin-arm64": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.14.tgz",
+          "integrity": "sha512-mUljW63ljx7gDn8ZFov+7AHTbQ6afU7CGwQFdpyoBW8XKFdHz6DPBllpMq5mMv2gDhQdpJUhdU0b/fNDl7d9QQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-darwin-x64": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.14.tgz",
+          "integrity": "sha512-3/TplaFuUfukvR+50xHdAkRRAjZWuT4+V4xn8puel22Qx53gGi2Bh6pdAKXDDeoSEvF2bozrOeKZm04lPaAQOQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-arm64-gnu": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.14.tgz",
+          "integrity": "sha512-HPTWqZZlPsjS489ByX8RtgYoodn4IcSFrdTdi8gyLCKNfq7hf7uwWP5/dJQK/EW+wVch8HkrOJECxdXHRCDFIg==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-arm64-musl": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.14.tgz",
+          "integrity": "sha512-8d0VFLlUatZJp/Z/udpV7kW3g3Uyrenr5bu6w5oETIv7Bv1T6IR3as7R0s2dONa7JkuAw4gQB0c1k9X44SxoBQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-x64-gnu": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.14.tgz",
+          "integrity": "sha512-Hy7z+orffDzQ5Jt3CSF9kncCPPGWyDS6Bs4FgSbYiOgoB314tdpgBSkdrh6wiG5inXLbOFI5Mc3Gct5hK0ok/w==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-x64-musl": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.14.tgz",
+          "integrity": "sha512-m/DEip/dJhUuFCLZggOllBAHsRtBmUfRk/YyzxaHLNEImR7/ZV2SIEU1krnicNsz5pO8pQ7mjPeFpio/XsHciQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-win32-arm64-msvc": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.14.tgz",
+          "integrity": "sha512-Mpj5on9HWHcQ2BnAXWm/OhwbrEtNYSr3Ab1v/0sGxFdufcqI5u7xRjFlLbgEUDmDb4Cfr4/VoWMvAKCIsilc6A==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-win32-ia32-msvc": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.14.tgz",
+          "integrity": "sha512-JwMCL+l2UicDPgQG6GCtDfxjahcCIMyWc+CCvFH9BeI4/XWU6O6m1kXbJfx0qLXRWAZQhALlpW9o8BE8Sr73dg==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-win32-x64-msvc": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.14.tgz",
+          "integrity": "sha512-QqcPv2II8YTRybuhMCnJXlz7xIvknwyaIlhflDcC2hNBGIo8H866A66cMY/r3bDVcrrVpgx79yFeJ+a/pyjdHQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/core": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.14.tgz",
+          "integrity": "sha512-B76vRdbKXMi/Xjd8Q0f/4xrlqp4mFELH2w+6ROoAscGVgS8eDsWmJHa7ddIB3FELizzDvI3BjGfBeGftZjSg3g==",
+          "dev": true,
+          "requires": {
+            "@rspack/binding": "0.3.14",
+            "@swc/helpers": "0.5.1",
+            "browserslist": "^4.21.3",
+            "compare-versions": "6.0.0-rc.1",
+            "enhanced-resolve": "5.12.0",
+            "fast-querystring": "1.1.2",
+            "graceful-fs": "4.2.10",
+            "json-parse-even-better-errors": "^3.0.0",
+            "neo-async": "2.6.2",
+            "react-refresh": "0.14.0",
+            "tapable": "2.2.1",
+            "terminal-link": "^2.1.1",
+            "watchpack": "^2.4.0",
+            "webpack-sources": "3.2.3",
+            "zod": "^3.21.4",
+            "zod-validation-error": "1.2.0"
+          }
+        }
       }
     },
     "@rsbuild/plugin-react": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-react/-/plugin-react-0.0.24.tgz",
-      "integrity": "sha512-GnWIenfLCiZIJ3c+uGbQslpIgNgvzQ4Y7q1MeuK4ve7LRTxCMl5UhngZ2OL9/o6kR3XLl0oWLWadLR32crANAg==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-react/-/plugin-react-0.0.28.tgz",
+      "integrity": "sha512-iaMn7h+0hFkAz2lhV6D2HykbvgrqbHqn3oTfh02LcT6+0nUd27JYh1/aHek+JUsH34BbGbw0DkTS+A/sc78aqQ==",
       "dev": true,
       "requires": {
-        "@rsbuild/shared": "0.0.24",
-        "@rspack/plugin-react-refresh": "0.3.13",
-        "react-refresh": "^0.14.0"
+        "@rsbuild/shared": "0.0.28",
+        "@rspack/plugin-react-refresh": "0.3.14",
+        "react-refresh": "^0.14.0",
+        "semver": "^7.5.4"
+      },
+      "dependencies": {
+        "@rsbuild/shared": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.0.28.tgz",
+          "integrity": "sha512-UPTGkiAm2DNlNmrhnQZTlTYcHb63aWY5fmQIZ4hTgfTAl991ldS9Z7Tq0dGEmuZng5pJ5dHbBUXHQGTzKq9wxA==",
+          "dev": true,
+          "requires": {
+            "@rspack/core": "0.3.14",
+            "caniuse-lite": "^1.0.30001559",
+            "line-diff": "2.1.1",
+            "lodash": "^4.17.21",
+            "postcss": "8.4.31"
+          }
+        },
+        "@rspack/binding": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.3.14.tgz",
+          "integrity": "sha512-kcbhfvrXqxf2NQsidnRxZ4ab/Vvxm2timNZIWu5BgXi8hPAXayG+JyDEQMVC0xj5qlDrJid+z7J4U0IIHi5RrQ==",
+          "dev": true,
+          "requires": {
+            "@rspack/binding-darwin-arm64": "0.3.14",
+            "@rspack/binding-darwin-x64": "0.3.14",
+            "@rspack/binding-linux-arm64-gnu": "0.3.14",
+            "@rspack/binding-linux-arm64-musl": "0.3.14",
+            "@rspack/binding-linux-x64-gnu": "0.3.14",
+            "@rspack/binding-linux-x64-musl": "0.3.14",
+            "@rspack/binding-win32-arm64-msvc": "0.3.14",
+            "@rspack/binding-win32-ia32-msvc": "0.3.14",
+            "@rspack/binding-win32-x64-msvc": "0.3.14"
+          }
+        },
+        "@rspack/binding-darwin-arm64": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.3.14.tgz",
+          "integrity": "sha512-mUljW63ljx7gDn8ZFov+7AHTbQ6afU7CGwQFdpyoBW8XKFdHz6DPBllpMq5mMv2gDhQdpJUhdU0b/fNDl7d9QQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-darwin-x64": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.3.14.tgz",
+          "integrity": "sha512-3/TplaFuUfukvR+50xHdAkRRAjZWuT4+V4xn8puel22Qx53gGi2Bh6pdAKXDDeoSEvF2bozrOeKZm04lPaAQOQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-arm64-gnu": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.3.14.tgz",
+          "integrity": "sha512-HPTWqZZlPsjS489ByX8RtgYoodn4IcSFrdTdi8gyLCKNfq7hf7uwWP5/dJQK/EW+wVch8HkrOJECxdXHRCDFIg==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-arm64-musl": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.3.14.tgz",
+          "integrity": "sha512-8d0VFLlUatZJp/Z/udpV7kW3g3Uyrenr5bu6w5oETIv7Bv1T6IR3as7R0s2dONa7JkuAw4gQB0c1k9X44SxoBQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-x64-gnu": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.3.14.tgz",
+          "integrity": "sha512-Hy7z+orffDzQ5Jt3CSF9kncCPPGWyDS6Bs4FgSbYiOgoB314tdpgBSkdrh6wiG5inXLbOFI5Mc3Gct5hK0ok/w==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-linux-x64-musl": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.3.14.tgz",
+          "integrity": "sha512-m/DEip/dJhUuFCLZggOllBAHsRtBmUfRk/YyzxaHLNEImR7/ZV2SIEU1krnicNsz5pO8pQ7mjPeFpio/XsHciQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-win32-arm64-msvc": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.3.14.tgz",
+          "integrity": "sha512-Mpj5on9HWHcQ2BnAXWm/OhwbrEtNYSr3Ab1v/0sGxFdufcqI5u7xRjFlLbgEUDmDb4Cfr4/VoWMvAKCIsilc6A==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-win32-ia32-msvc": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.3.14.tgz",
+          "integrity": "sha512-JwMCL+l2UicDPgQG6GCtDfxjahcCIMyWc+CCvFH9BeI4/XWU6O6m1kXbJfx0qLXRWAZQhALlpW9o8BE8Sr73dg==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/binding-win32-x64-msvc": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.3.14.tgz",
+          "integrity": "sha512-QqcPv2II8YTRybuhMCnJXlz7xIvknwyaIlhflDcC2hNBGIo8H866A66cMY/r3bDVcrrVpgx79yFeJ+a/pyjdHQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@rspack/core": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.3.14.tgz",
+          "integrity": "sha512-B76vRdbKXMi/Xjd8Q0f/4xrlqp4mFELH2w+6ROoAscGVgS8eDsWmJHa7ddIB3FELizzDvI3BjGfBeGftZjSg3g==",
+          "dev": true,
+          "requires": {
+            "@rspack/binding": "0.3.14",
+            "@swc/helpers": "0.5.1",
+            "browserslist": "^4.21.3",
+            "compare-versions": "6.0.0-rc.1",
+            "enhanced-resolve": "5.12.0",
+            "fast-querystring": "1.1.2",
+            "graceful-fs": "4.2.10",
+            "json-parse-even-better-errors": "^3.0.0",
+            "neo-async": "2.6.2",
+            "react-refresh": "0.14.0",
+            "tapable": "2.2.1",
+            "terminal-link": "^2.1.1",
+            "watchpack": "^2.4.0",
+            "webpack-sources": "3.2.3",
+            "zod": "^3.21.4",
+            "zod-validation-error": "1.2.0"
+          }
+        },
+        "@rspack/plugin-react-refresh": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@rspack/plugin-react-refresh/-/plugin-react-refresh-0.3.14.tgz",
+          "integrity": "sha512-xHMDOHpQdI7aTJHdVUJMDyE5KM+5bGNcDCY+kptITTrIfiL4RtpIQYa0w0kSZR+/JqgFgviZgqJLW8gnnS1b8Q==",
+          "dev": true,
+          "requires": {
+            "@pmmmwh/react-refresh-webpack-plugin": "0.5.10"
+          }
+        }
       }
     },
     "@rsbuild/shared": {
@@ -12251,16 +12698,6 @@
         "set-function-length": "^1.1.1"
       }
     },
-    "camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "caniuse-lite": {
       "version": "1.0.30001562",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
@@ -12324,15 +12761,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
-    },
-    "clean-css": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
-      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
-      "dev": true,
-      "requires": {
-        "source-map": "~0.6.0"
-      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -12429,12 +12857,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
-    },
-    "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true
     },
     "common-path-prefix": {
       "version": "3.0.0",
@@ -12698,16 +13120,6 @@
         "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
@@ -12804,12 +13216,6 @@
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
       }
-    },
-    "entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true
     },
     "err-code": {
       "version": "2.0.3",
@@ -13497,28 +13903,12 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
       "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ=="
     },
-    "html-minifier-terser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "dev": true,
-      "requires": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      }
-    },
     "html-webpack-plugin": {
-      "version": "npm:html-rspack-plugin@5.5.5",
-      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.5.tgz",
-      "integrity": "sha512-IXwQK2HcH2GYdqlW4lwzhXStXNqhvOjd0fwOto7H4wBE+xN8F2b9aVCR2zkhxTxs1G09b4tBqehD7cOWiAhNeQ==",
+      "version": "npm:html-rspack-plugin@5.5.7",
+      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.7.tgz",
+      "integrity": "sha512-7dNAURj9XBHWoYg59F8VU6hT7J7w+od4Lr5hc/rrgN6sy6QfqVpoPqW9Qw4IGFOgit8Pul7iQp1yysBSIhOlsg==",
       "dev": true,
       "requires": {
-        "html-minifier-terser": "^7.2.0",
         "lodash": "^4.17.21",
         "tapable": "^2.0.0"
       }
@@ -13828,12 +14218,6 @@
         }
       }
     },
-    "jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13972,15 +14356,6 @@
       "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
       }
     },
     "lru-cache": {
@@ -14696,16 +15071,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
-    "no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -14923,16 +15288,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
-    "param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "parse-entities": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
@@ -14962,16 +15317,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
-    "pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "path-exists": {
       "version": "4.0.0",
@@ -15345,12 +15690,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
       "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
-    },
-    "relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true
     },
     "remark-frontmatter": {
       "version": "4.0.1",
@@ -15741,17 +16080,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "sirv": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
-      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
-      "dev": true,
-      "requires": {
-        "@polka/url": "^1.0.0-next.20",
-        "mrmime": "^1.0.0",
-        "totalist": "^3.0.0"
-      }
     },
     "sockjs": {
       "version": "0.3.24",
@@ -16179,12 +16507,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
-    },
-    "totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true
     },
     "tr46": {
       "version": "0.0.3",

--- a/playground/package.json
+++ b/playground/package.json
@@ -10,8 +10,8 @@
     "dev": "NODE_ENV=development node ./build.mjs"
   },
   "devDependencies": {
-    "@rsbuild/core": "^0.0.24",
-    "@rsbuild/plugin-react": "^0.0.24",
+    "@rsbuild/core": "^0.0.28",
+    "@rsbuild/plugin-react": "^0.0.28",
     "@types/node": "^20.9.1"
   },
   "dependencies": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -59,19 +59,23 @@ export const pluginFoo = (remixOptions = {}) => ({ // Export a function that ret
       const remixConfig = await remixOptions; // Await the remixOptions promise
       const isModule = remixConfig.serverModuleFormat === 'esm'; // Check if the server module format is 'esm'
       if (!options.isServer) { // If the options do not include 'isServer'
-        setConfig(config, 'externalsType', 'module'); // Set the externals type to 'module'
         setConfig(config, 'target', 'web'); // Set the target to 'web'
         setConfig(config, 'name', 'browser'); // Set the name to 'browser'
         setConfig(config, 'output.publicPath', remixConfig.publicPath || 'auto'); // Set the public path to the remix config public path or 'auto' if it does not exist
-        setConfig(config, 'output.module', true); // Set the output module to true
-        setConfig(config, 'output.library', { type: 'module' }); // Set the output library type to 'module'
-        setConfig(config, 'output.chunkFormat', 'module'); // Set the output chunk format to 'module'
-        setConfig(config, 'output.chunkLoading', 'import'); // Set the output chunk loading to 'import'
+
+        // Rspack HMR do not support module chunk format yet
+        // ref: https://github.com/web-infra-dev/rspack/blob/37ba8d745312c05bf81ae3a1e21a19f503dcd010/crates/rspack_plugin_runtime/src/module_chunk_format.rs#L95-L97
+        // setConfig(config, 'output.module', true); // Set the output module to true
+        // setConfig(config, 'output.library', { type: 'module' }); // Set the output library type to 'module'
+        // setConfig(config, 'output.chunkFormat', 'module'); // Set the output chunk format to 'module'
+        // setConfig(config, 'output.chunkLoading', 'import'); // Set the output chunk loading to 'import'
+        // setConfig(config, 'experiments.outputModule', true); // Set the experiments output module to true
+        // setConfig(config, 'externalsType', 'module'); // Set the externals type to 'module'
+
         setConfig(config, 'output.assetModuleFilename', '_assets/[name]-[contenthash][ext]'); // Set the output asset module filename
         setConfig(config, 'output.cssChunkFilename', '_assets/[name]-[contenthash].css'); // Set the output CSS chunk filename
         setConfig(config, 'output.filename', '[name]-[contenthash].js'); // Set the output filename
         setConfig(config, 'output.chunkFilename', '[name]-[contenthash].js'); // Set the output chunk filename
-        setConfig(config, 'experiments.outputModule', true); // Set the experiments output module to true
         config.plugins.push(new RemixAssetsManifestPlugin(remixConfig)); // Push a new instance of RemixAssetsManifestPlugin to the plugins array
       } else {
         const ext = isModule ? 'mjs' : 'js'; // Set the extension to 'mjs' if the server module format is 'esm', otherwise set it to 'js'


### PR DESCRIPTION
Make dev server works by:

- Bump Rsbuild v0.0.28
- Remove `output.module` options in client bundles, as Rspack HMR do not support module chunk format yet.

Ref: https://github.com/web-infra-dev/rspack/blob/37ba8d745312c05bf81ae3a1e21a19f503dcd010/crates/rspack_plugin_runtime/src/module_chunk_format.rs#L95-L97

Visit: http://localhost:8080/root

![image](https://github.com/ScriptedAlchemy/remix/assets/7237365/7deb18d2-994a-45b7-ada2-b489d1fcd57b)
